### PR TITLE
Error budget calculation based on alerts.

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -7,9 +7,11 @@ import (
 )
 
 type Alert struct {
-	MonitorID string
-	OpenedAt  time.Time
-	ClosedAt  *time.Time
+	MonitorID   string
+	MonitorName string
+	MonitorType string
+	OpenedAt    time.Time
+	ClosedAt    *time.Time
 }
 
 type Alerts []*Alert

--- a/alert.go
+++ b/alert.go
@@ -1,6 +1,10 @@
 package shimesaba
 
-import "time"
+import (
+	"time"
+
+	"github.com/Songmu/flextime"
+)
 
 type Alert struct {
 	MonitorID string
@@ -9,3 +13,25 @@ type Alert struct {
 }
 
 type Alerts []*Alert
+
+func (alerts Alerts) StartAt() time.Time {
+	startAt := flextime.Now()
+	for _, alert := range alerts {
+		if alert.OpenedAt.Before(startAt) {
+			startAt = alert.OpenedAt
+		}
+	}
+	return startAt
+}
+func (alerts Alerts) EndAt() time.Time {
+	endAt := time.Unix(0, 0)
+	for _, alert := range alerts {
+		if alert.ClosedAt == nil {
+			return flextime.Now()
+		}
+		if alert.ClosedAt.After(endAt) {
+			endAt = *alert.ClosedAt
+		}
+	}
+	return endAt
+}

--- a/alert.go
+++ b/alert.go
@@ -8,31 +8,27 @@ import (
 )
 
 type Alert struct {
-	MonitorID   string
-	MonitorName string
-	MonitorType string
-	OpenedAt    time.Time
-	ClosedAt    *time.Time
+	Monitor  *Monitor
+	OpenedAt time.Time
+	ClosedAt *time.Time
 }
 
-func NewAlert(monitorId, monitorName, monitorType string, openedAt time.Time, closedAt *time.Time) *Alert {
+func NewAlert(monitor *Monitor, openedAt time.Time, closedAt *time.Time) *Alert {
 	if closedAt != nil {
 		tmp := closedAt.Truncate(time.Minute).UTC()
 		closedAt = &tmp
 	}
 	return &Alert{
-		MonitorID:   monitorId,
-		MonitorName: monitorName,
-		MonitorType: monitorType,
-		OpenedAt:    openedAt.Truncate(time.Minute).UTC(),
-		ClosedAt:    closedAt,
+		Monitor:  monitor,
+		OpenedAt: openedAt.Truncate(time.Minute).UTC(),
+		ClosedAt: closedAt,
 	}
 }
 
 func (alert *Alert) String() string {
-	return fmt.Sprintf("alert[%s] %s %s ~ %s",
-		alert.MonitorID,
-		alert.MonitorName,
+	return fmt.Sprintf("alert[%s:%s] %s ~ %s",
+		alert.Monitor.ID,
+		alert.Monitor.Name,
 		alert.OpenedAt,
 		alert.ClosedAt,
 	)

--- a/alert.go
+++ b/alert.go
@@ -1,6 +1,7 @@
 package shimesaba
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Songmu/flextime"
@@ -12,6 +13,29 @@ type Alert struct {
 	MonitorType string
 	OpenedAt    time.Time
 	ClosedAt    *time.Time
+}
+
+func NewAlert(monitorId, monitorName, monitorType string, openedAt time.Time, closedAt *time.Time) *Alert {
+	if closedAt != nil {
+		tmp := closedAt.Truncate(time.Minute).UTC()
+		closedAt = &tmp
+	}
+	return &Alert{
+		MonitorID:   monitorId,
+		MonitorName: monitorName,
+		MonitorType: monitorType,
+		OpenedAt:    openedAt.Truncate(time.Minute).UTC(),
+		ClosedAt:    closedAt,
+	}
+}
+
+func (alert *Alert) String() string {
+	return fmt.Sprintf("alert[%s] %s %s ~ %s",
+		alert.MonitorID,
+		alert.MonitorName,
+		alert.OpenedAt,
+		alert.ClosedAt,
+	)
 }
 
 type Alerts []*Alert

--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,11 @@
+package shimesaba
+
+import "time"
+
+type Alert struct {
+	MonitorID string
+	OpenedAt  time.Time
+	ClosedAt  *time.Time
+}
+
+type Alerts []*Alert

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -51,18 +51,27 @@ func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
 }
 
 func (o AlertObjective) matchAlert(alert *Alert) bool {
-	log.Printf("[debug] try match alert %v vs %v", o.cfg, alert)
-	if o.cfg.MonitorID != "" && alert.MonitorID != o.cfg.MonitorID {
-		return false
+	log.Printf("[debug] try match %s vs %v", alert, o.cfg)
+	if o.cfg.MonitorID != "" {
+		if alert.MonitorID != o.cfg.MonitorID {
+			return false
+		}
 	}
-	if o.cfg.MonitorNamePrefix != "" && !strings.HasPrefix(alert.MonitorName, o.cfg.MonitorNamePrefix) {
-		return false
+	if o.cfg.MonitorNamePrefix != "" {
+		if !strings.HasPrefix(alert.MonitorName, o.cfg.MonitorNamePrefix) {
+			return false
+		}
 	}
-	if o.cfg.MonitorNameSuffix != "" && !strings.HasSuffix(alert.MonitorName, o.cfg.MonitorNameSuffix) {
-		return false
+	if o.cfg.MonitorNameSuffix != "" {
+		if !strings.HasSuffix(alert.MonitorName, o.cfg.MonitorNameSuffix) {
+			return false
+		}
 	}
-	if o.cfg.MonitorType != "" && !strings.EqualFold(alert.MonitorType, o.cfg.MonitorType) {
-		return false
+	if o.cfg.MonitorType != "" {
+		if !strings.EqualFold(alert.MonitorType, o.cfg.MonitorType) {
+			return false
+		}
 	}
+	log.Printf("[debug] match %s", alert)
 	return true
 }

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -53,22 +53,22 @@ func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
 func (o AlertObjective) matchAlert(alert *Alert) bool {
 	log.Printf("[debug] try match %s vs %v", alert, o.cfg)
 	if o.cfg.MonitorID != "" {
-		if alert.MonitorID != o.cfg.MonitorID {
+		if alert.Monitor.ID != o.cfg.MonitorID {
 			return false
 		}
 	}
 	if o.cfg.MonitorNamePrefix != "" {
-		if !strings.HasPrefix(alert.MonitorName, o.cfg.MonitorNamePrefix) {
+		if !strings.HasPrefix(alert.Monitor.Name, o.cfg.MonitorNamePrefix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorNameSuffix != "" {
-		if !strings.HasSuffix(alert.MonitorName, o.cfg.MonitorNameSuffix) {
+		if !strings.HasSuffix(alert.Monitor.Name, o.cfg.MonitorNameSuffix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorType != "" {
-		if !strings.EqualFold(alert.MonitorType, o.cfg.MonitorType) {
+		if !strings.EqualFold(alert.Monitor.Type, o.cfg.MonitorType) {
 			return false
 		}
 	}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -1,0 +1,58 @@
+package shimesaba
+
+import (
+	"time"
+
+	"github.com/Songmu/flextime"
+	"github.com/mashiike/shimesaba/internal/timeutils"
+)
+
+type AlertObjective struct {
+	cfg *AlertObjectiveConfig
+}
+
+func NewAlertObjective(cfg *AlertObjectiveConfig) *AlertObjective {
+	return &AlertObjective{cfg: cfg}
+}
+
+func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts Alerts) (ReliabilityCollection, error) {
+	isNoViolation := o.newIsNoViolation(alerts)
+	startAt := alerts.StartAt().Truncate(timeFrame).Add(timeFrame)
+	endAt := alerts.EndAt().Truncate(timeFrame).Add(-timeFrame)
+
+	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
+	iter.SetEnableOverWindow(true)
+	reliabilitySlice := make([]*Reliability, 0)
+	for iter.HasNext() {
+		cursorAt, _ := iter.Next()
+		reliabilitySlice = append(reliabilitySlice, NewReliability(cursorAt, timeFrame, isNoViolation))
+	}
+	return NewReliabilityCollection(reliabilitySlice)
+}
+
+func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
+	now := flextime.Now().Add(time.Minute)
+	isNoViolation := make(map[time.Time]bool)
+	for _, alert := range alerts {
+		if !o.matchAlert(alert) {
+			continue
+		}
+		closedAt := now
+		if alert.ClosedAt != nil {
+			closedAt = *alert.ClosedAt
+		}
+		iter := timeutils.NewIterator(alert.OpenedAt, closedAt, time.Minute)
+		for iter.HasNext() {
+			t, _ := iter.Next()
+			isNoViolation[t] = false
+		}
+	}
+	return isNoViolation
+}
+
+func (o AlertObjective) matchAlert(alert *Alert) bool {
+	if o.cfg.MonitorID != "" && alert.MonitorID != o.cfg.MonitorID {
+		return false
+	}
+	return true
+}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -1,6 +1,7 @@
 package shimesaba
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Songmu/flextime"
@@ -50,6 +51,15 @@ func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
 
 func (o AlertObjective) matchAlert(alert *Alert) bool {
 	if o.cfg.MonitorID != "" && alert.MonitorID != o.cfg.MonitorID {
+		return false
+	}
+	if o.cfg.MonitorNamePrefix != "" && !strings.HasPrefix(alert.MonitorName, o.cfg.MonitorNamePrefix) {
+		return false
+	}
+	if o.cfg.MonitorNameSuffix != "" && !strings.HasSuffix(alert.MonitorName, o.cfg.MonitorNameSuffix) {
+		return false
+	}
+	if o.cfg.MonitorType != "" && !strings.EqualFold(alert.MonitorType, o.cfg.MonitorType) {
 		return false
 	}
 	return true

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -52,26 +52,33 @@ func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
 
 func (o AlertObjective) matchAlert(alert *Alert) bool {
 	log.Printf("[debug] try match %s vs %v", alert, o.cfg)
+	if o.MatchMonitor(alert.Monitor) {
+		log.Printf("[debug] match %s", alert)
+		return true
+	}
+	return false
+}
+
+func (o AlertObjective) MatchMonitor(monitor *Monitor) bool {
 	if o.cfg.MonitorID != "" {
-		if alert.Monitor.ID != o.cfg.MonitorID {
+		if monitor.ID != o.cfg.MonitorID {
 			return false
 		}
 	}
 	if o.cfg.MonitorNamePrefix != "" {
-		if !strings.HasPrefix(alert.Monitor.Name, o.cfg.MonitorNamePrefix) {
+		if !strings.HasPrefix(monitor.Name, o.cfg.MonitorNamePrefix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorNameSuffix != "" {
-		if !strings.HasSuffix(alert.Monitor.Name, o.cfg.MonitorNameSuffix) {
+		if !strings.HasSuffix(monitor.Name, o.cfg.MonitorNameSuffix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorType != "" {
-		if !strings.EqualFold(alert.Monitor.Type, o.cfg.MonitorType) {
+		if !strings.EqualFold(monitor.Type, o.cfg.MonitorType) {
 			return false
 		}
 	}
-	log.Printf("[debug] match %s", alert)
 	return true
 }

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -1,6 +1,7 @@
 package shimesaba
 
 import (
+	"log"
 	"strings"
 	"time"
 
@@ -50,6 +51,7 @@ func (o AlertObjective) newIsNoViolation(alerts Alerts) map[time.Time]bool {
 }
 
 func (o AlertObjective) matchAlert(alert *Alert) bool {
+	log.Printf("[debug] try match alert %v vs %v", o.cfg, alert)
 	if o.cfg.MonitorID != "" && alert.MonitorID != o.cfg.MonitorID {
 		return false
 	}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -15,10 +15,8 @@ func NewAlertObjective(cfg *AlertObjectiveConfig) *AlertObjective {
 	return &AlertObjective{cfg: cfg}
 }
 
-func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts Alerts) (ReliabilityCollection, error) {
+func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (ReliabilityCollection, error) {
 	isNoViolation := o.newIsNoViolation(alerts)
-	startAt := alerts.StartAt().Truncate(timeFrame).Add(timeFrame)
-	endAt := alerts.EndAt().Truncate(timeFrame).Add(-timeFrame)
 
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -14,34 +14,42 @@ func TestAlertObjective(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC))
 	defer restore()
 	alerts := shimesaba.Alerts{
-		{
-			MonitorID:   "hogera",
-			MonitorName: "SLO hoge",
-			MonitorType: "expression",
-			OpenedAt:    time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
-			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID:   "fugara",
-			MonitorName: "SLO fuga",
-			MonitorType: "service",
-			OpenedAt:    time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
-			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID:   "fugara",
-			MonitorName: "SLO fuga",
-			MonitorType: "service",
-			OpenedAt:    time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
-			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID:   "hogera",
-			MonitorName: "SLO hoge",
-			MonitorType: "expression",
-			OpenedAt:    time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
-			ClosedAt:    nil,
-		},
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID:   "hogera",
+				Name: "SLO hoge",
+				Type: "expression",
+			},
+			time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID:   "fugara",
+				Name: "SLO fuga",
+				Type: "service",
+			},
+			time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID:   "fugara",
+				Name: "SLO fuga",
+				Type: "service",
+			},
+			time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID:   "hogera",
+				Name: "SLO hoge",
+				Type: "expression",
+			},
+			time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			nil,
+		),
 	}
 	cases := []struct {
 		cfg      *shimesaba.AlertObjectiveConfig

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -67,9 +67,15 @@ func TestAlertObjective(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
 			obj := shimesaba.NewAlertObjective(c.cfg)
-			actual, err := obj.NewReliabilityCollection(time.Minute, alerts)
+			actual, err := obj.NewReliabilityCollection(
+				time.Minute,
+				alerts,
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			)
 			require.NoError(t, err)
 			expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC), time.Minute, c.expected),

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -1,0 +1,87 @@
+package shimesaba_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Songmu/flextime"
+	"github.com/mashiike/shimesaba"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertObjective(t *testing.T) {
+	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC))
+	defer restore()
+	alerts := shimesaba.Alerts{
+		{
+			MonitorID: "hogera",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "hogera",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			ClosedAt:  nil,
+		},
+	}
+	cases := []struct {
+		cfg      *shimesaba.AlertObjectiveConfig
+		expected map[time.Time]bool
+	}{
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorID: "hogera",
+			},
+			expected: map[time.Time]bool{
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+			},
+		},
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorID: "fugara",
+			},
+			expected: map[time.Time]bool{
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): true,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC): true,
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): true,
+			},
+		},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
+			obj := shimesaba.NewAlertObjective(c.cfg)
+			actual, err := obj.NewReliabilityCollection(time.Minute, alerts)
+			require.NoError(t, err)
+			expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC), time.Minute, c.expected),
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC), time.Minute, c.expected),
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), time.Minute, c.expected),
+			})
+			require.EqualValues(t, expected, actual)
+		})
+	}
+
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -15,24 +15,32 @@ func TestAlertObjective(t *testing.T) {
 	defer restore()
 	alerts := shimesaba.Alerts{
 		{
-			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
+			MonitorID:   "hogera",
+			MonitorName: "SLO hoge",
+			MonitorType: "expression",
+			OpenedAt:    time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
 		},
 		{
-			MonitorID: "fugara",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
+			MonitorID:   "fugara",
+			MonitorName: "SLO fuga",
+			MonitorType: "service",
+			OpenedAt:    time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
 		},
 		{
-			MonitorID: "fugara",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+			MonitorID:   "fugara",
+			MonitorName: "SLO fuga",
+			MonitorType: "service",
+			OpenedAt:    time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+			ClosedAt:    ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 		},
 		{
-			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
-			ClosedAt:  nil,
+			MonitorID:   "hogera",
+			MonitorName: "SLO hoge",
+			MonitorType: "expression",
+			OpenedAt:    time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			ClosedAt:    nil,
 		},
 	}
 	cases := []struct {
@@ -42,6 +50,17 @@ func TestAlertObjective(t *testing.T) {
 		{
 			cfg: &shimesaba.AlertObjectiveConfig{
 				MonitorID: "hogera",
+			},
+			expected: map[time.Time]bool{
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+			},
+		},
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorNameSuffix: "hoge",
 			},
 			expected: map[time.Time]bool{
 				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): false,
@@ -62,6 +81,38 @@ func TestAlertObjective(t *testing.T) {
 				time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
 				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): true,
 			},
+		},
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorNamePrefix: "SLO",
+			},
+			expected: map[time.Time]bool{
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+			},
+		},
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorNamePrefix: "SLO",
+				MonitorType:       "Expression",
+			},
+			expected: map[time.Time]bool{
+				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): false,
+				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+			},
+		},
+		{
+			cfg: &shimesaba.AlertObjectiveConfig{
+				MonitorNameSuffix: "hoge",
+				MonitorType:       "service",
+			},
+			expected: map[time.Time]bool{},
 		},
 	}
 	for i, c := range cases {

--- a/alert_test.go
+++ b/alert_test.go
@@ -13,29 +13,37 @@ func TestAlerts(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC))
 	defer restore()
 	alerts := shimesaba.Alerts{
-		{
-			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID: "fugara",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID: "fugara",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
-		},
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID: "hogera",
+			},
+			time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID: "fugara",
+			},
+			time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID: "fugara",
+			},
+			time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+		),
 	}
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), alerts.EndAt())
-	alerts = append(alerts, &shimesaba.Alert{
-		MonitorID: "hogera",
-		OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
-		ClosedAt:  nil,
-	})
+	alerts = append(alerts, shimesaba.NewAlert(
+		&shimesaba.Monitor{
+			ID: "hogera",
+		},
+		time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+		nil,
+	))
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
 }

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,0 +1,41 @@
+package shimesaba_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Songmu/flextime"
+	"github.com/mashiike/shimesaba"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlerts(t *testing.T) {
+	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC))
+	defer restore()
+	alerts := shimesaba.Alerts{
+		{
+			MonitorID: "hogera",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+		},
+	}
+	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
+	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), alerts.EndAt())
+	alerts = append(alerts, &shimesaba.Alert{
+		MonitorID: "hogera",
+		OpenedAt:  time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
+		ClosedAt:  nil,
+	})
+	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
+	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
+}

--- a/app.go
+++ b/app.go
@@ -88,9 +88,15 @@ func (app *App) Run(ctx context.Context, optFns ...func(*Options)) error {
 		return err
 	}
 	log.Println("[info] fetched metrics", metrics)
+	log.Printf("[info] fetch alerts range %s ~ %s", startAt, now)
+	alerts, err := app.repo.FetchAlerts(ctx, startAt, now)
+	if err != nil {
+		return err
+	}
+	log.Println("[info] fetched alerts", len(alerts))
 	for _, d := range app.definitions {
 		log.Printf("[info] check objectives[%s]\n", d.ID())
-		reports, err := d.CreateReports(ctx, metrics)
+		reports, err := d.CreateReports(ctx, metrics, alerts)
 		if err != nil {
 			return fmt.Errorf("objective[%s] create report failed: %w", d.ID(), err)
 		}

--- a/app_test.go
+++ b/app_test.go
@@ -155,3 +155,17 @@ func (m *mockMackerelClient) PostServiceMetricValues(serviceName string, metricV
 	m.posted = append(m.posted, metricValues...)
 	return nil
 }
+
+func (m *mockMackerelClient) FindWithClosedAlerts() (*mackerel.AlertsResp, error) {
+	return &mackerel.AlertsResp{
+		Alerts: make([]*mackerel.Alert, 0),
+		NextID: "dummyNextID",
+	}, nil
+}
+func (m *mockMackerelClient) FindWithClosedAlertsByNextID(nextID string) (*mackerel.AlertsResp, error) {
+	require.Equal(m.t, "dummyNextID", nextID)
+	return &mackerel.AlertsResp{
+		Alerts: make([]*mackerel.Alert, 0),
+		NextID: "",
+	}, nil
+}

--- a/app_test.go
+++ b/app_test.go
@@ -158,14 +158,43 @@ func (m *mockMackerelClient) PostServiceMetricValues(serviceName string, metricV
 
 func (m *mockMackerelClient) FindWithClosedAlerts() (*mackerel.AlertsResp, error) {
 	return &mackerel.AlertsResp{
-		Alerts: make([]*mackerel.Alert, 0),
+		Alerts: []*mackerel.Alert{
+			{
+				ID:        "dummyID20211001-001900",
+				Status:    "WARNING",
+				MonitorID: "dummyMonitorID",
+				OpenedAt:  time.Date(2021, 10, 1, 0, 19, 0, 0, time.UTC).Unix(),
+				Value:     0.01,
+				Type:      "service",
+			},
+		},
 		NextID: "dummyNextID",
 	}, nil
 }
+
 func (m *mockMackerelClient) FindWithClosedAlertsByNextID(nextID string) (*mackerel.AlertsResp, error) {
 	require.Equal(m.t, "dummyNextID", nextID)
 	return &mackerel.AlertsResp{
-		Alerts: make([]*mackerel.Alert, 0),
+		Alerts: []*mackerel.Alert{
+			{
+				ID:        "dummyID20211001-001000",
+				Status:    "OK",
+				MonitorID: "dummyMonitorID",
+				OpenedAt:  time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
+				ClosedAt:  time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
+				Value:     0.01,
+				Type:      "service",
+			},
+		},
 		NextID: "",
+	}, nil
+}
+
+func (m *mockMackerelClient) GetMonitor(monitorID string) (mackerel.Monitor, error) {
+	require.Equal(m.t, "dummyMonitorID", monitorID)
+	return &mackerel.MonitorServiceMetric{
+		ID:   monitorID,
+		Name: "Dummy Service Metric Monitor",
+		Type: "service",
 	}, nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -51,6 +51,17 @@ func TestAppWithMock(t *testing.T) {
 						"shimesaba.uptime.check":                                backfill,
 					},
 				},
+				{
+					configFile: "testdata/alert_source.yaml",
+					expected: map[string]int{
+						"shimesaba.error_budget.alerts":                        backfill,
+						"shimesaba.error_budget_consumption.alerts":            backfill,
+						"shimesaba.error_budget_consumption_percentage.alerts": backfill,
+						"shimesaba.error_budget_percentage.alerts":             backfill,
+						"shimesaba.failure_time.alerts":                        backfill,
+						"shimesaba.uptime.alerts":                              backfill,
+					},
+				},
 			}
 			for _, c := range cases {
 				t.Run(c.configFile, func(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -330,15 +330,25 @@ func (c *ObjectiveConfig) Type() string {
 }
 
 type AlertObjectiveConfig struct {
-	MonitorID string `json:"monitor_id" yaml:"monitor_id"`
+	MonitorID         string `json:"monitor_id,omitempty" yaml:"monitor_id,omitempty"`
+	MonitorNamePrefix string `json:"monitor_name_prefix,omitempty" yaml:"monitor_name_prefix,omitempty"`
+	MonitorNameSuffix string `json:"monitor_name_suffix,omitempty" yaml:"monitor_name_suffix,omitempty"`
+	MonitorType       string `json:"monitor_type,omitempty" yaml:"monitor_type,omitempty"`
 }
 
 // Restrict restricts a configuration.
 func (c *AlertObjectiveConfig) Restrict() error {
-	if c.MonitorID == "" {
-		return errors.New("monitor_id is required")
+	if c.MonitorID != "" {
+		return nil
 	}
-	return nil
+	if c.MonitorNamePrefix != "" {
+		return nil
+	}
+	if c.MonitorNameSuffix != "" {
+		return nil
+	}
+
+	return errors.New("either monitor_id, monitor_name_prefix, monitor_name_suffix or monitor_type is required")
 }
 
 // DefinitionConfigs is a collection of DefinitionConfigs that corrects the uniqueness of IDs.

--- a/config.go
+++ b/config.go
@@ -408,6 +408,9 @@ func (c *DefinitionConfigs) UnmarshalYAML(unmarshal func(interface{}) error) err
 
 // Load loads configuration file from file paths.
 func (c *Config) Load(paths ...string) error {
+	if len(paths) == 0 {
+		return errors.New("no config")
+	}
 	if err := gc.LoadWithEnv(c, paths...); err != nil {
 		return err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -2,8 +2,10 @@ package shimesaba_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/mashiike/shimesaba"
 	"github.com/mashiike/shimesaba/internal/logger"
@@ -44,6 +46,49 @@ func TestConfigLoadNoError(t *testing.T) {
 			require.NoError(t, err)
 			err = cfg.Restrict()
 			require.NoError(t, err)
+		})
+	}
+
+}
+
+func TestDefinitionConfigStartAt(t *testing.T) {
+	cases := []struct {
+		now      time.Time
+		backfill int
+		cfg      *shimesaba.DefinitionConfig
+		expected time.Time
+	}{
+		{
+			now:      time.Date(2022, 1, 14, 3, 13, 23, 999, time.UTC),
+			backfill: 3,
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "1d",
+				ErrorBudgetSize:   0.05,
+				CalculateInterval: "1h",
+			},
+			expected: time.Date(2022, 1, 13, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			now:      time.Date(2022, 1, 14, 3, 13, 23, 999, time.UTC),
+			backfill: 3,
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "365d",
+				ErrorBudgetSize:   0.05,
+				CalculateInterval: "1d",
+			},
+			expected: time.Date(2021, 1, 11, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
+			require.NoError(t, c.cfg.Restrict())
+			actual := c.cfg.StartAt(c.now, c.backfill)
+			require.EqualValues(t, c.expected, actual)
 		})
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -25,6 +25,10 @@ func TestConfigLoadNoError(t *testing.T) {
 			casename: "simple_config",
 			paths:    []string{"testdata/simple.yaml"},
 		},
+		{
+			casename: "alert_source_config",
+			paths:    []string{"testdata/alert_source.yaml"},
+		},
 	}
 
 	for _, c := range cases {

--- a/dashboard.go
+++ b/dashboard.go
@@ -77,17 +77,14 @@ func (app *App) loadDashboard() (*Dashboard, error) {
 	}
 	definitions := make(map[string]interface{}, len(app.definitions))
 	for _, def := range app.definitions {
-		objectives := make([]string, 0, len(def.objectives))
-		for _, obj := range def.objectives {
-			objectives = append(objectives, obj.String())
-		}
+		exprObjectives := def.ExprObjectives()
 		definitions[def.id] = map[string]interface{}{
 			"TimeFrame":               timeutils.DurationString(def.timeFrame),
 			"ServiceName":             def.serviceName,
 			"CalculateInterval":       timeutils.DurationString(def.calculate),
 			"ErrorBudgetSize":         def.errorBudgetSize,
 			"ErrorBudgetSizeDuration": timeutils.DurationString(time.Duration(def.errorBudgetSize * float64(def.timeFrame)).Truncate(time.Minute)),
-			"Objectives":              objectives,
+			"Objectives":              exprObjectives,
 		}
 	}
 	data := map[string]interface{}{

--- a/dashboard.go
+++ b/dashboard.go
@@ -75,8 +75,12 @@ func (app *App) loadDashboard() (*Dashboard, error) {
 	if app.dashboardPath == "" {
 		return nil, errors.New("dashboard file path is not configured")
 	}
-	definitions := make(map[string]interface{}, len(app.definitions))
-	for _, def := range app.definitions {
+	definitions := make(map[string]interface{}, len(app.definitionConfigs))
+	for _, defCfg := range app.definitionConfigs {
+		def, err := NewDefinition(defCfg)
+		if err != nil {
+			return nil, err
+		}
 		exprObjectives := def.ExprObjectives()
 		definitions[def.id] = map[string]interface{}{
 			"TimeFrame":               timeutils.DurationString(def.timeFrame),

--- a/definition.go
+++ b/definition.go
@@ -55,7 +55,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	}
 	endAt := metrics.EndAt()
 	if tmpEndAt := alerts.EndAt(); tmpEndAt.After(endAt) {
-		endAt = endAt
+		endAt = tmpEndAt
 	}
 	log.Printf("[debug] original report range = %s ~ %s", startAt, endAt)
 	startAt = startAt.Add(d.timeFrame).Truncate(d.timeFrame)

--- a/definition.go
+++ b/definition.go
@@ -95,3 +95,19 @@ func (d *Definition) ExprObjectives() []string {
 	}
 	return objectives
 }
+
+func (d *Definition) AlertObjectives(monitors []*Monitor) []*Monitor {
+	matched := make(map[string]*Monitor)
+	for _, m := range monitors {
+		for _, obj := range d.alertObjectives {
+			if obj.MatchMonitor(m) {
+				matched[m.ID] = m
+			}
+		}
+	}
+	objectiveMonitors := make([]*Monitor, 0, len(matched))
+	for _, monitor := range matched {
+		objectiveMonitors = append(objectiveMonitors, monitor)
+	}
+	return objectiveMonitors
+}

--- a/definition.go
+++ b/definition.go
@@ -55,6 +55,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	log.Printf("[debug] truncate report range = %s ~ %s", startAt, endAt)
 	log.Printf("[debug] timeFrame = %s, calcurateInterval = %s", d.timeFrame, d.calculate)
 	var reliabilityCollection ReliabilityCollection
+	log.Printf("[debug] expr objective count = %d", len(d.exprObjectives))
 	for _, o := range d.exprObjectives {
 		rc, err := o.NewReliabilityCollection(d.calculate, metrics, startAt, endAt)
 		if err != nil {
@@ -65,6 +66,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 			return nil, err
 		}
 	}
+	log.Printf("[debug] alert objective count = %d", len(d.alertObjectives))
 	for _, o := range d.alertObjectives {
 		rc, err := o.NewReliabilityCollection(d.calculate, alerts, startAt, endAt)
 		if err != nil {

--- a/definition_test.go
+++ b/definition_test.go
@@ -64,16 +64,20 @@ func TestDefinition(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, 10, 01, 0, 22, 0, 0, time.UTC))
 	defer restore()
 	alerts := shimesaba.Alerts{
-		{
-			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 9, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 15, 0, 0, time.UTC),
-			ClosedAt:  nil,
-		},
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID: "hogera",
+			},
+			time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC),
+			ptrTime(time.Date(2021, 10, 1, 0, 9, 0, 0, time.UTC)),
+		),
+		shimesaba.NewAlert(
+			&shimesaba.Monitor{
+				ID: "hogera",
+			},
+			time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC),
+			nil,
+		),
 	}
 	cases := []struct {
 		defCfg   *shimesaba.DefinitionConfig

--- a/definition_test.go
+++ b/definition_test.go
@@ -239,7 +239,10 @@ func TestDefinition(t *testing.T) {
 			}()
 			def, err := shimesaba.NewDefinition(c.defCfg)
 			require.NoError(t, err)
-			actual, err := def.CreateReports(context.Background(), metrics, alerts)
+			actual, err := def.CreateReports(context.Background(), metrics, alerts,
+				time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
+				time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
+			)
 			require.NoError(t, err)
 			t.Log("actual:")
 			for _, a := range actual {

--- a/definition_test.go
+++ b/definition_test.go
@@ -61,27 +61,17 @@ func TestDefinition(t *testing.T) {
 		}
 		metrics.Set(metric)
 	}
-	restore := flextime.Fix(time.Date(2021, 10, 01, 0, 30, 0, 0, time.UTC))
+	restore := flextime.Fix(time.Date(2021, 10, 01, 0, 22, 0, 0, time.UTC))
 	defer restore()
 	alerts := shimesaba.Alerts{
 		{
 			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, 10, 1, 0, 0, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID: "fugara",
-			OpenedAt:  time.Date(2021, 10, 1, 0, 2, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 4, 0, 0, time.UTC)),
-		},
-		{
-			MonitorID: "fugara",
 			OpenedAt:  time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC),
-			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 5, 0, 0, time.UTC)),
+			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 9, 0, 0, time.UTC)),
 		},
 		{
 			MonitorID: "hogera",
-			OpenedAt:  time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 15, 0, 0, time.UTC),
 			ClosedAt:  nil,
 		},
 	}
@@ -182,6 +172,59 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetSize:        3 * time.Minute,
 					ErrorBudget:            2 * time.Minute,
 					ErrorBudgetConsumption: 1 * time.Minute,
+				},
+			},
+		},
+		{
+			defCfg: &shimesaba.DefinitionConfig{
+				ID:                "alert_and_metric_mixing",
+				TimeFrame:         "10m",
+				CalculateInterval: "5m",
+				ErrorBudgetSize:   0.3,
+				Objectives: []*shimesaba.ObjectiveConfig{
+					{
+						Expr: "rate(error_count, request_count) <= 0.5",
+					},
+					{
+						Alert: &shimesaba.AlertObjectiveConfig{
+							MonitorID: "hogera",
+						},
+					},
+				},
+			},
+			expected: []*shimesaba.Report{
+				{
+					DefinitionID:           "alert_and_metric_mixing",
+					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
+					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
+					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
+					UpTime:                 4 * time.Minute,
+					FailureTime:            6 * time.Minute,
+					ErrorBudgetSize:        3 * time.Minute,
+					ErrorBudget:            -3 * time.Minute,
+					ErrorBudgetConsumption: 4 * time.Minute,
+				},
+				{
+					DefinitionID:           "alert_and_metric_mixing",
+					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
+					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
+					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
+					UpTime:                 6 * time.Minute,
+					FailureTime:            4 * time.Minute,
+					ErrorBudgetSize:        3 * time.Minute,
+					ErrorBudget:            -1 * time.Minute,
+					ErrorBudgetConsumption: 0 * time.Minute,
+				},
+				{
+					DefinitionID:           "alert_and_metric_mixing",
+					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
+					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
+					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
+					UpTime:                 5 * time.Minute,
+					FailureTime:            5 * time.Minute,
+					ErrorBudgetSize:        3 * time.Minute,
+					ErrorBudget:            -2 * time.Minute,
+					ErrorBudgetConsumption: 5 * time.Minute,
 				},
 			},
 		},

--- a/definition_test.go
+++ b/definition_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Songmu/flextime"
 	"github.com/mashiike/shimesaba"
 	"github.com/mashiike/shimesaba/internal/logger"
 	"github.com/stretchr/testify/require"
@@ -59,6 +60,30 @@ func TestDefinition(t *testing.T) {
 			metric.AppendValue(tv.Time, tv.Value)
 		}
 		metrics.Set(metric)
+	}
+	restore := flextime.Fix(time.Date(2021, 10, 01, 0, 30, 0, 0, time.UTC))
+	defer restore()
+	alerts := shimesaba.Alerts{
+		{
+			MonitorID: "hogera",
+			OpenedAt:  time.Date(2021, 10, 1, 0, 0, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, 10, 1, 0, 2, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 4, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "fugara",
+			OpenedAt:  time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC),
+			ClosedAt:  ptrTime(time.Date(2021, 10, 1, 0, 5, 0, 0, time.UTC)),
+		},
+		{
+			MonitorID: "hogera",
+			OpenedAt:  time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
+			ClosedAt:  nil,
+		},
 	}
 	cases := []struct {
 		defCfg   *shimesaba.DefinitionConfig
@@ -171,7 +196,7 @@ func TestDefinition(t *testing.T) {
 			}()
 			def, err := shimesaba.NewDefinition(c.defCfg)
 			require.NoError(t, err)
-			actual, err := def.CreateReports(context.Background(), metrics)
+			actual, err := def.CreateReports(context.Background(), metrics, alerts)
 			require.NoError(t, err)
 			t.Log("actual:")
 			for _, a := range actual {

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -16,10 +16,8 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 	return &ExprObjective{expr: expr}
 }
 
-func (o *ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics Metrics) (ReliabilityCollection, error) {
+func (o *ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (ReliabilityCollection, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
-	startAt := metrics.StartAt().Truncate(timeFrame).Add(timeFrame)
-	endAt := metrics.EndAt().Truncate(timeFrame).Add(-timeFrame)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)
 	reliabilitySlice := make([]*Reliability, 0)

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -16,7 +16,7 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 	return &ExprObjective{expr: expr}
 }
 
-func (o ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics Metrics) (ReliabilityCollection, error) {
+func (o *ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics Metrics) (ReliabilityCollection, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
 	startAt := metrics.StartAt().Truncate(timeFrame).Add(timeFrame)
 	endAt := metrics.EndAt().Truncate(timeFrame).Add(-timeFrame)
@@ -30,7 +30,7 @@ func (o ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics
 	return NewReliabilityCollection(reliabilitySlice)
 }
 
-func (o ExprObjective) newIsNoViolation(metrics Metrics) map[time.Time]bool {
+func (o *ExprObjective) newIsNoViolation(metrics Metrics) map[time.Time]bool {
 	variables := metrics.GetVariables(metrics.StartAt(), metrics.EndAt())
 	ret := make(map[time.Time]bool, len(variables))
 	for t, v := range variables {
@@ -45,4 +45,8 @@ func (o ExprObjective) newIsNoViolation(metrics Metrics) map[time.Time]bool {
 		ret[t] = b
 	}
 	return ret
+}
+
+func (o *ExprObjective) String() string {
+	return o.expr.String()
 }

--- a/expr_objective_test.go
+++ b/expr_objective_test.go
@@ -76,11 +76,16 @@ func TestExprObjective(t *testing.T) {
 			comparator, ok := e.AsComparator()
 			require.EqualValues(t, true, ok)
 			obj := shimesaba.NewExprObjective(comparator)
-			actual, err := obj.NewReliabilityCollection(time.Minute, metrics)
+			actual, err := obj.NewReliabilityCollection(
+				time.Minute,
+				metrics,
+				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC),
+				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			)
 			require.NoError(t, err)
-			require.EqualValues(t, 1, len(actual), "only 1 tumbling window")
 			expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
+				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),
 			})
 			require.EqualValues(t, expected, actual)
 		})

--- a/mackerel.go
+++ b/mackerel.go
@@ -339,13 +339,20 @@ func (repo *Repository) convertAlerts(resp *mackerel.AlertsResp, endAt time.Time
 		if err != nil {
 			return nil, err
 		}
-		alerts = append(alerts, &Alert{
+		alert := &Alert{
 			MonitorID:   alert.MonitorID,
 			MonitorName: monitor.MonitorName(),
 			MonitorType: monitor.MonitorType(),
 			OpenedAt:    openedAt,
 			ClosedAt:    closedAt,
-		})
+		}
+		log.Printf("[debug] alert[%s] %s %s ~ %s",
+			alert.MonitorID,
+			alert.MonitorName,
+			alert.OpenedAt,
+			alert.ClosedAt,
+		)
+		alerts = append(alerts, alert)
 	}
 	return alerts, nil
 }
@@ -357,11 +364,12 @@ func (repo *Repository) getMonitor(id string) (mackerel.Monitor, error) {
 	if monitor, ok := repo.monitorByID[id]; ok {
 		return monitor, nil
 	}
-
+	log.Printf("[debug] call GetMonitor(%s)", id)
 	monitor, err := repo.client.GetMonitor(id)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("[debug] catch monitor[%s] = %#v", id, monitor)
 	repo.monitorByID[id] = monitor
 	return monitor, nil
 }

--- a/mackerel.go
+++ b/mackerel.go
@@ -339,19 +339,14 @@ func (repo *Repository) convertAlerts(resp *mackerel.AlertsResp, endAt time.Time
 		if err != nil {
 			return nil, err
 		}
-		alert := &Alert{
-			MonitorID:   alert.MonitorID,
-			MonitorName: monitor.MonitorName(),
-			MonitorType: monitor.MonitorType(),
-			OpenedAt:    openedAt,
-			ClosedAt:    closedAt,
-		}
-		log.Printf("[debug] alert[%s] %s %s ~ %s",
+		alert := NewAlert(
 			alert.MonitorID,
-			alert.MonitorName,
-			alert.OpenedAt,
-			alert.ClosedAt,
+			monitor.MonitorName(),
+			monitor.MonitorType(),
+			openedAt,
+			closedAt,
 		)
+		log.Printf("[debug] %s", alert)
 		alerts = append(alerts, alert)
 	}
 	return alerts, nil

--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,13 @@
+package shimesaba
+
+import "fmt"
+
+type Monitor struct {
+	ID   string
+	Name string
+	Type string
+}
+
+func (m *Monitor) String() string {
+	return fmt.Sprintf("[%s]%s", m.Type, m.Name)
+}

--- a/reliability.go
+++ b/reliability.go
@@ -2,6 +2,7 @@ package shimesaba
 
 import (
 	"errors"
+	"log"
 	"sort"
 	"time"
 
@@ -27,7 +28,7 @@ func (c IsNoViolationCollection) IsUp(t time.Time) bool {
 }
 
 func NewReliability(cursorAt time.Time, timeFrame time.Duration, isNoViolation IsNoViolationCollection) *Reliability {
-	cursorAt = cursorAt.Truncate(timeFrame).Add(timeFrame)
+	cursorAt = cursorAt.Truncate(timeFrame).Add(timeFrame).UTC()
 	r := &Reliability{
 		cursorAt:      cursorAt,
 		timeFrame:     timeFrame,
@@ -154,10 +155,18 @@ func (c ReliabilityCollection) Clone() ReliabilityCollection {
 
 func (c ReliabilityCollection) CalcTime(cursor, n int) (upTime, failureTime, deltaFailureTime time.Duration) {
 	deltaFailureTime = c[cursor].FailureTime()
-	for i := cursor; i < cursor+n && i < c.Len(); i++ {
+	i := cursor
+	for ; i < cursor+n && i < c.Len(); i++ {
 		upTime += c[i].UpTime()
 		failureTime += c[i].FailureTime()
 	}
+	log.Printf("[debug] CalcTime[%s~%s] = (%s, %s, %s)",
+		c[cursor].TimeFrameStartAt(),
+		c[i-1].TimeFrameEndAt(),
+		upTime,
+		failureTime,
+		deltaFailureTime,
+	)
 	return
 }
 

--- a/testdata/alert_source.yaml
+++ b/testdata/alert_source.yaml
@@ -1,4 +1,4 @@
-required_version: ">=0.0.0"
+required_version: ">=0.6.0"
 
 definitions:
   - id: latency

--- a/testdata/alert_source.yaml
+++ b/testdata/alert_source.yaml
@@ -1,14 +1,14 @@
 required_version: ">=0.6.0"
 
 definitions:
-  - id: latency
+  - id: alerts
     service_name:  shimesaba
     time_frame: 5m
     calculate_interval: 1m
     error_budget_size: 0.1
     objectives:
       - alert:
-          monitor_id: "axekau1jia"
+          monitor_id: "dummyMonitorID"
       - alert:
-          monitor_id: "hoekna2jia"
+          monitor_name_prefix: "Dummy"
 

--- a/testdata/alert_source.yaml
+++ b/testdata/alert_source.yaml
@@ -1,0 +1,14 @@
+required_version: ">=0.0.0"
+
+definitions:
+  - id: latency
+    service_name:  shimesaba
+    time_frame: 5m
+    calculate_interval: 1m
+    error_budget_size: 0.1
+    objectives:
+      - alert:
+          monitor_id: "axekau1jia"
+      - alert:
+          monitor_id: "hoekna2jia"
+


### PR DESCRIPTION
Add the ability to calculate error budgets on an experimental alert basis.

For this purpose, we have the following experimental trials
- Support for planned maintenance: Planned maintenance can be configured to not trigger alerts on Mackerel. If we can calculate the error budget based on alerts, it will be easier to exclude planned maintenance from the error budget calculation.
- Support for SLOs for external monitoring: I would like to be able to set SLOs based on external monitoring, anomaly detection, and connectivity rather than metrics. Also, by supporting expression monitoring, I expect support for intuitive graph display.

Translated with www.DeepL.com/Translator (free version)