### PR TITLE
Extend the way the configuration is written.

### DIFF
--- a/config.go
+++ b/config.go
@@ -180,10 +180,10 @@ type DefinitionConfig struct {
 	ID                string             `json:"id" yaml:"id"`
 	TimeFrame         string             `yaml:"time_frame" json:"time_frame"`
 	ServiceName       string             `json:"service_name" yaml:"service_name"`
+	MetricPrefix      string             `json:"metric_prefix" yaml:"metric_prefix"`
 	ErrorBudgetSize   float64            `yaml:"error_budget_size" json:"error_budget_size"`
 	CalculateInterval string             `yaml:"calculate_interval" json:"calculate_interval"`
 	Objectives        []*ObjectiveConfig `json:"objectives" yaml:"objectives"`
-
 	calculateInterval time.Duration
 	timeFrame         time.Duration
 }
@@ -200,6 +200,10 @@ func (c *DefinitionConfig) MergeInto(o *DefinitionConfig) {
 	c.Objectives = append(c.Objectives, o.Objectives...)
 }
 
+const (
+	defaultMetricPrefix = "shimesaba"
+)
+
 // Restrict restricts a definition configuration.
 func (c *DefinitionConfig) Restrict() error {
 	if c.ID == "" {
@@ -207,6 +211,9 @@ func (c *DefinitionConfig) Restrict() error {
 	}
 	if c.ServiceName == "" {
 		return errors.New("service_name is required")
+	}
+	if c.MetricPrefix == "" {
+		c.MetricPrefix = defaultMetricPrefix
 	}
 	if c.ErrorBudgetSize >= 1.0 || c.ErrorBudgetSize <= 0.0 {
 		return errors.New("error_budget must between 1.0 and 0.0")

--- a/config.go
+++ b/config.go
@@ -188,6 +188,7 @@ type DefinitionConfig struct {
 	TimeFrame         string             `yaml:"time_frame" json:"time_frame"`
 	ServiceName       string             `json:"service_name" yaml:"service_name"`
 	MetricPrefix      string             `json:"metric_prefix" yaml:"metric_prefix"`
+	MetricSuffix      string             `json:"metric_suffix" yaml:"metric_suffix"`
 	ErrorBudgetSize   interface{}        `yaml:"error_budget_size" json:"error_budget_size"`
 	CalculateInterval string             `yaml:"calculate_interval" json:"calculate_interval"`
 	Objectives        []*ObjectiveConfig `json:"objectives" yaml:"objectives"`
@@ -225,7 +226,9 @@ func (c *DefinitionConfig) Restrict() error {
 	if c.MetricPrefix == "" {
 		c.MetricPrefix = defaultMetricPrefix
 	}
-
+	if c.MetricSuffix == "" {
+		c.MetricSuffix = c.ID
+	}
 	for i, objective := range c.Objectives {
 		if err := objective.Restrict(); err != nil {
 			return fmt.Errorf("objective[%d] %w", i, err)

--- a/config_test.go
+++ b/config_test.go
@@ -31,6 +31,10 @@ func TestConfigLoadNoError(t *testing.T) {
 			casename: "alert_source_config",
 			paths:    []string{"testdata/alert_source.yaml"},
 		},
+		{
+			casename: "sample_config",
+			paths:    []string{"testdata/sample.yaml"},
+		},
 	}
 
 	for _, c := range cases {

--- a/config_test.go
+++ b/config_test.go
@@ -95,5 +95,75 @@ func TestDefinitionConfigStartAt(t *testing.T) {
 			require.EqualValues(t, c.expected, actual)
 		})
 	}
+}
 
+func TestDefinitionConfigErrorBudgetSize(t *testing.T) {
+	cases := []struct {
+		cfg         *shimesaba.DefinitionConfig
+		exceptedErr bool
+		expected    float64
+	}{
+		{
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "28d",
+				ErrorBudgetSize:   0.001,
+				CalculateInterval: "1h",
+			},
+			expected: 0.001,
+		},
+		{
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "28d",
+				ErrorBudgetSize:   "40m",
+				CalculateInterval: "1d",
+			},
+			expected: 0.001,
+		},
+		{
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "28d",
+				ErrorBudgetSize:   "0.001%",
+				CalculateInterval: "1d",
+			},
+			expected: 0.001,
+		},
+		{
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "28d",
+				ErrorBudgetSize:   "5m0.001%",
+				CalculateInterval: "1d",
+			},
+			exceptedErr: true,
+		},
+		{
+			cfg: &shimesaba.DefinitionConfig{
+				ID:                "test",
+				ServiceName:       "shimesaba",
+				TimeFrame:         "28d",
+				ErrorBudgetSize:   "0.01",
+				CalculateInterval: "1d",
+			},
+			exceptedErr: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
+			err := c.cfg.Restrict()
+			if !c.exceptedErr {
+				require.NoError(t, err)
+				require.InEpsilon(t, c.expected, c.cfg.ErrorBudgetSizeParcentage(), 0.01)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
 }

--- a/dashboard.go
+++ b/dashboard.go
@@ -94,7 +94,8 @@ func (app *App) loadDashboard() (*Dashboard, error) {
 		}
 		definitions[def.id] = map[string]interface{}{
 			"TimeFrame":               timeutils.DurationString(def.timeFrame),
-			"ServiceName":             def.serviceName,
+			"ServiceName":             def.destination.ServiceName,
+			"Destination":             def.destination,
 			"CalculateInterval":       timeutils.DurationString(def.calculate),
 			"ErrorBudgetSize":         def.errorBudgetSize,
 			"ErrorBudgetSizeDuration": timeutils.DurationString(time.Duration(def.errorBudgetSize * float64(def.timeFrame)).Truncate(time.Minute)),

--- a/definition.go
+++ b/definition.go
@@ -10,8 +10,7 @@ import (
 //Definition is SLI/SLO Definition
 type Definition struct {
 	id              string
-	serviceName     string
-	metricPrefix    string
+	destination     *Destination
 	timeFrame       time.Duration
 	calculate       time.Duration
 	errorBudgetSize float64
@@ -33,9 +32,12 @@ func NewDefinition(cfg *DefinitionConfig) (*Definition, error) {
 		}
 	}
 	return &Definition{
-		id:              cfg.ID,
-		serviceName:     cfg.ServiceName,
-		metricPrefix:    cfg.MetricPrefix,
+		id: cfg.ID,
+		destination: &Destination{
+			ServiceName:  cfg.ServiceName,
+			MetricPrefix: cfg.MetricPrefix,
+			MetricSuffix: cfg.MetricSuffix,
+		},
 		timeFrame:       cfg.DurationTimeFrame(),
 		calculate:       cfg.DurationCalculate(),
 		errorBudgetSize: cfg.ErrorBudgetSizeParcentage(),
@@ -82,7 +84,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	for _, r := range reliabilityCollection {
 		log.Printf("[debug] reliability[%s~%s] =  (%s, %s)", r.TimeFrameStartAt(), r.TimeFrameEndAt(), r.UpTime(), r.FailureTime())
 	}
-	reports := NewReports(d.id, d.serviceName, d.metricPrefix, d.errorBudgetSize, d.timeFrame, reliabilityCollection)
+	reports := NewReports(d.id, d.destination, d.errorBudgetSize, d.timeFrame, reliabilityCollection)
 	sort.Slice(reports, func(i, j int) bool {
 		return reports[i].DataPoint.Before(reports[j].DataPoint)
 	})

--- a/definition.go
+++ b/definition.go
@@ -11,6 +11,7 @@ import (
 type Definition struct {
 	id              string
 	serviceName     string
+	metricPrefix    string
 	timeFrame       time.Duration
 	calculate       time.Duration
 	errorBudgetSize float64
@@ -34,6 +35,7 @@ func NewDefinition(cfg *DefinitionConfig) (*Definition, error) {
 	return &Definition{
 		id:              cfg.ID,
 		serviceName:     cfg.ServiceName,
+		metricPrefix:    cfg.MetricPrefix,
 		timeFrame:       cfg.DurationTimeFrame(),
 		calculate:       cfg.DurationCalculate(),
 		errorBudgetSize: cfg.ErrorBudgetSize,
@@ -80,7 +82,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	for _, r := range reliabilityCollection {
 		log.Printf("[debug] reliability[%s~%s] =  (%s, %s)", r.TimeFrameStartAt(), r.TimeFrameEndAt(), r.UpTime(), r.FailureTime())
 	}
-	reports := NewReports(d.id, d.serviceName, d.errorBudgetSize, d.timeFrame, reliabilityCollection)
+	reports := NewReports(d.id, d.serviceName, d.metricPrefix, d.errorBudgetSize, d.timeFrame, reliabilityCollection)
 	sort.Slice(reports, func(i, j int) bool {
 		return reports[i].DataPoint.Before(reports[j].DataPoint)
 	})

--- a/definition.go
+++ b/definition.go
@@ -38,7 +38,7 @@ func NewDefinition(cfg *DefinitionConfig) (*Definition, error) {
 		metricPrefix:    cfg.MetricPrefix,
 		timeFrame:       cfg.DurationTimeFrame(),
 		calculate:       cfg.DurationCalculate(),
-		errorBudgetSize: cfg.ErrorBudgetSize,
+		errorBudgetSize: cfg.ErrorBudgetSizeParcentage(),
 		exprObjectives:  exprObjectives,
 		alertObjectives: alertObjectives,
 	}, nil

--- a/definition_test.go
+++ b/definition_test.go
@@ -98,9 +98,12 @@ func TestDefinition(t *testing.T) {
 			},
 			expected: []*shimesaba.Report{
 				{
-					DefinitionID:           "test1",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "test1",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "test1",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -111,9 +114,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 0,
 				},
 				{
-					DefinitionID:           "test1",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "test1",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "test1",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -124,9 +130,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 4 * time.Minute,
 				},
 				{
-					DefinitionID:           "test1",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "test1",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "test1",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
@@ -153,9 +162,12 @@ func TestDefinition(t *testing.T) {
 			},
 			expected: []*shimesaba.Report{
 				{
-					DefinitionID:           "error_rate",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "error_rate",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "error_rate",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -166,9 +178,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 0,
 				},
 				{
-					DefinitionID:           "error_rate",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "error_rate",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "error_rate",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -179,9 +194,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 0 * time.Minute,
 				},
 				{
-					DefinitionID:           "error_rate",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "error_rate",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "error_rate",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
@@ -213,9 +231,12 @@ func TestDefinition(t *testing.T) {
 			},
 			expected: []*shimesaba.Report{
 				{
-					DefinitionID:           "alert_and_metric_mixing",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "alert_and_metric_mixing",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "alert_and_metric_mixing",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -226,9 +247,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 4 * time.Minute,
 				},
 				{
-					DefinitionID:           "alert_and_metric_mixing",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "alert_and_metric_mixing",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "alert_and_metric_mixing",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -239,9 +263,12 @@ func TestDefinition(t *testing.T) {
 					ErrorBudgetConsumption: 0 * time.Minute,
 				},
 				{
-					DefinitionID:           "alert_and_metric_mixing",
-					ServiceName:            "test",
-					MetricPrefix:           "shimesaba",
+					DefinitionID: "alert_and_metric_mixing",
+					Destination: &shimesaba.Destination{
+						ServiceName:  "test",
+						MetricPrefix: "shimesaba",
+						MetricSuffix: "alert_and_metric_mixing",
+					},
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),

--- a/definition_test.go
+++ b/definition_test.go
@@ -86,9 +86,10 @@ func TestDefinition(t *testing.T) {
 		{
 			defCfg: &shimesaba.DefinitionConfig{
 				ID:                "test1",
+				ServiceName:       "test",
 				TimeFrame:         "10m",
 				CalculateInterval: "5m",
-				ErrorBudgetSize:   0.3,
+				ErrorBudgetSize:   "3m",
 				Objectives: []*shimesaba.ObjectiveConfig{
 					{
 						Expr: "dummy3 < 1.0",
@@ -98,6 +99,8 @@ func TestDefinition(t *testing.T) {
 			expected: []*shimesaba.Report{
 				{
 					DefinitionID:           "test1",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -109,6 +112,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "test1",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -120,6 +125,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "test1",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
@@ -134,6 +141,7 @@ func TestDefinition(t *testing.T) {
 		{
 			defCfg: &shimesaba.DefinitionConfig{
 				ID:                "error_rate",
+				ServiceName:       "test",
 				TimeFrame:         "10m",
 				CalculateInterval: "5m",
 				ErrorBudgetSize:   0.3,
@@ -146,6 +154,8 @@ func TestDefinition(t *testing.T) {
 			expected: []*shimesaba.Report{
 				{
 					DefinitionID:           "error_rate",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -157,6 +167,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "error_rate",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -168,6 +180,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "error_rate",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
@@ -182,6 +196,7 @@ func TestDefinition(t *testing.T) {
 		{
 			defCfg: &shimesaba.DefinitionConfig{
 				ID:                "alert_and_metric_mixing",
+				ServiceName:       "test",
 				TimeFrame:         "10m",
 				CalculateInterval: "5m",
 				ErrorBudgetSize:   0.3,
@@ -199,6 +214,8 @@ func TestDefinition(t *testing.T) {
 			expected: []*shimesaba.Report{
 				{
 					DefinitionID:           "alert_and_metric_mixing",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 0, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 9, 59, 999999999, time.UTC),
@@ -210,6 +227,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "alert_and_metric_mixing",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 15, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 5, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 14, 59, 999999999, time.UTC),
@@ -221,6 +240,8 @@ func TestDefinition(t *testing.T) {
 				},
 				{
 					DefinitionID:           "alert_and_metric_mixing",
+					ServiceName:            "test",
+					MetricPrefix:           "shimesaba",
 					DataPoint:              time.Date(2021, 10, 01, 0, 20, 0, 0, time.UTC),
 					TimeFrameStartAt:       time.Date(2021, 10, 01, 0, 10, 0, 0, time.UTC),
 					TimeFrameEndAt:         time.Date(2021, 10, 01, 0, 19, 59, 999999999, time.UTC),
@@ -241,6 +262,8 @@ func TestDefinition(t *testing.T) {
 				t.Log(buf.String())
 				logger.Setup(os.Stderr, "info")
 			}()
+			err := c.defCfg.Restrict()
+			require.NoError(t, err)
 			def, err := shimesaba.NewDefinition(c.defCfg)
 			require.NoError(t, err)
 			actual, err := def.CreateReports(context.Background(), metrics, alerts,

--- a/destination.go
+++ b/destination.go
@@ -1,0 +1,33 @@
+package shimesaba
+
+import "fmt"
+
+type Destination struct {
+	ServiceName  string
+	MetricPrefix string
+	MetricSuffix string
+}
+
+func (d *Destination) ErrorBudgetMetricName() string {
+	return fmt.Sprintf("%s.error_budget.%s", d.MetricPrefix, d.MetricSuffix)
+}
+
+func (d *Destination) ErrorBudgetPercentageMetricName() string {
+	return fmt.Sprintf("%s.error_budget_percentage.%s", d.MetricPrefix, d.MetricSuffix)
+}
+
+func (d *Destination) ErrorBudgetConsumptionMetricName() string {
+	return fmt.Sprintf("%s.error_budget_consumption.%s", d.MetricPrefix, d.MetricSuffix)
+}
+
+func (d *Destination) ErrorBudgetConsumptionPercentageMetricName() string {
+	return fmt.Sprintf("%s.error_budget_consumption_percentage.%s", d.MetricPrefix, d.MetricSuffix)
+}
+
+func (d *Destination) UpTimeMetricName() string {
+	return fmt.Sprintf("%s.uptime.%s", d.MetricPrefix, d.MetricSuffix)
+}
+
+func (d *Destination) FailureMetricName() string {
+	return fmt.Sprintf("%s.failure_time.%s", d.MetricPrefix, d.MetricSuffix)
+}

--- a/mackerel.go
+++ b/mackerel.go
@@ -130,10 +130,6 @@ func (repo *Repository) FetchMetrics(ctx context.Context, cfgs MetricConfigs, st
 	return ms, nil
 }
 
-const (
-	mackerelMetricPrefix = "shimesaba"
-)
-
 // SaveReports posts Reports to Mackerel
 func (repo *Repository) SaveReports(ctx context.Context, reports []*Report) error {
 	services := make(map[string][]*mackerel.MetricValue)
@@ -191,32 +187,32 @@ func (repo *Repository) postServiceMetricValues(ctx context.Context, service str
 func newMackerelMetricValuesFromReport(report *Report) []*mackerel.MetricValue {
 	values := make([]*mackerel.MetricValue, 0, 5)
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.error_budget.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudget.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_percentage.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.error_budget_percentage.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetUsageRate() * 100.0,
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_consumption.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.error_budget_consumption.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetConsumption.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_consumption_percentage.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.error_budget_consumption_percentage.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetConsumptionRate() * 100.0,
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.uptime.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.uptime.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.UpTime.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.failure_time.%s", mackerelMetricPrefix, report.DefinitionID),
+		Name:  fmt.Sprintf("%s.failure_time.%s", report.MetricPrefix, report.DefinitionID),
 		Time:  report.DataPoint.Unix(),
 		Value: report.FailureTime.Minutes(),
 	})

--- a/mackerel.go
+++ b/mackerel.go
@@ -134,12 +134,12 @@ func (repo *Repository) FetchMetrics(ctx context.Context, cfgs MetricConfigs, st
 func (repo *Repository) SaveReports(ctx context.Context, reports []*Report) error {
 	services := make(map[string][]*mackerel.MetricValue)
 	for _, report := range reports {
-		values, ok := services[report.ServiceName]
+		values, ok := services[report.Destination.ServiceName]
 		if !ok {
 			values = make([]*mackerel.MetricValue, 0)
 		}
 		values = append(values, newMackerelMetricValuesFromReport(report)...)
-		services[report.ServiceName] = values
+		services[report.Destination.ServiceName] = values
 	}
 	for service, values := range services {
 		select {
@@ -187,32 +187,32 @@ func (repo *Repository) postServiceMetricValues(ctx context.Context, service str
 func newMackerelMetricValuesFromReport(report *Report) []*mackerel.MetricValue {
 	values := make([]*mackerel.MetricValue, 0, 5)
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.ErrorBudgetMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudget.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_percentage.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.ErrorBudgetPercentageMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetUsageRate() * 100.0,
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_consumption.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.ErrorBudgetConsumptionMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetConsumption.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.error_budget_consumption_percentage.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.ErrorBudgetConsumptionPercentageMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.ErrorBudgetConsumptionRate() * 100.0,
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.uptime.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.UpTimeMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.UpTime.Minutes(),
 	})
 	values = append(values, &mackerel.MetricValue{
-		Name:  fmt.Sprintf("%s.failure_time.%s", report.MetricPrefix, report.DefinitionID),
+		Name:  report.Destination.FailureMetricName(),
 		Time:  report.DataPoint.Unix(),
 		Value: report.FailureTime.Minutes(),
 	})

--- a/report.go
+++ b/report.go
@@ -10,6 +10,7 @@ import (
 type Report struct {
 	DefinitionID           string
 	ServiceName            string
+	MetricPrefix           string
 	DataPoint              time.Time
 	TimeFrameStartAt       time.Time
 	TimeFrameEndAt         time.Time
@@ -20,7 +21,7 @@ type Report struct {
 	ErrorBudgetConsumption time.Duration
 }
 
-func NewReport(definitionID string, serviceName string, cursorAt time.Time, timeFrame time.Duration, errorBudgetSize float64) *Report {
+func NewReport(definitionID string, serviceName string, metricPrefix string, cursorAt time.Time, timeFrame time.Duration, errorBudgetSize float64) *Report {
 	report := &Report{
 		DefinitionID:     definitionID,
 		ServiceName:      serviceName,
@@ -32,7 +33,7 @@ func NewReport(definitionID string, serviceName string, cursorAt time.Time, time
 	return report
 }
 
-func NewReports(definitionID string, serviceName string, errorBudgetSize float64, timeFrame time.Duration, reliability ReliabilityCollection) []*Report {
+func NewReports(definitionID string, serviceName string, metricPrefix string, errorBudgetSize float64, timeFrame time.Duration, reliability ReliabilityCollection) []*Report {
 	if reliability.Len() == 0 {
 		return make([]*Report, 0)
 	}
@@ -44,6 +45,7 @@ func NewReports(definitionID string, serviceName string, errorBudgetSize float64
 		report := NewReport(
 			definitionID,
 			serviceName,
+			metricPrefix,
 			reliability.CursorAt(i),
 			timeFrame,
 			errorBudgetSize,

--- a/report.go
+++ b/report.go
@@ -25,6 +25,7 @@ func NewReport(definitionID string, serviceName string, metricPrefix string, cur
 	report := &Report{
 		DefinitionID:     definitionID,
 		ServiceName:      serviceName,
+		MetricPrefix:     metricPrefix,
 		DataPoint:        cursorAt,
 		TimeFrameStartAt: cursorAt.Add(-timeFrame),
 		TimeFrameEndAt:   cursorAt.Add(-time.Nanosecond),

--- a/report.go
+++ b/report.go
@@ -9,8 +9,7 @@ import (
 // Report has SLI/SLO/ErrorBudget numbers in one rolling window
 type Report struct {
 	DefinitionID           string
-	ServiceName            string
-	MetricPrefix           string
+	Destination            *Destination
 	DataPoint              time.Time
 	TimeFrameStartAt       time.Time
 	TimeFrameEndAt         time.Time
@@ -21,11 +20,10 @@ type Report struct {
 	ErrorBudgetConsumption time.Duration
 }
 
-func NewReport(definitionID string, serviceName string, metricPrefix string, cursorAt time.Time, timeFrame time.Duration, errorBudgetSize float64) *Report {
+func NewReport(definitionID string, destination *Destination, cursorAt time.Time, timeFrame time.Duration, errorBudgetSize float64) *Report {
 	report := &Report{
 		DefinitionID:     definitionID,
-		ServiceName:      serviceName,
-		MetricPrefix:     metricPrefix,
+		Destination:      destination,
 		DataPoint:        cursorAt,
 		TimeFrameStartAt: cursorAt.Add(-timeFrame),
 		TimeFrameEndAt:   cursorAt.Add(-time.Nanosecond),
@@ -34,7 +32,7 @@ func NewReport(definitionID string, serviceName string, metricPrefix string, cur
 	return report
 }
 
-func NewReports(definitionID string, serviceName string, metricPrefix string, errorBudgetSize float64, timeFrame time.Duration, reliability ReliabilityCollection) []*Report {
+func NewReports(definitionID string, destination *Destination, errorBudgetSize float64, timeFrame time.Duration, reliability ReliabilityCollection) []*Report {
 	if reliability.Len() == 0 {
 		return make([]*Report, 0)
 	}
@@ -45,8 +43,7 @@ func NewReports(definitionID string, serviceName string, metricPrefix string, er
 	for i := 0; i < numReports; i++ {
 		report := NewReport(
 			definitionID,
-			serviceName,
-			metricPrefix,
+			destination,
 			reliability.CursorAt(i),
 			timeFrame,
 			errorBudgetSize,

--- a/report_test.go
+++ b/report_test.go
@@ -107,6 +107,7 @@ func TestNewReports(t *testing.T) {
 		{
 			DefinitionID:           "test",
 			ServiceName:            "test",
+			MetricPrefix:           "test",
 			DataPoint:              time.Date(2022, 1, 6, 11, 0, 0, 0, time.UTC),
 			TimeFrameStartAt:       time.Date(2022, 1, 6, 9, 0, 0, 0, time.UTC),
 			TimeFrameEndAt:         time.Date(2022, 1, 6, 11, 0, 0, 0, time.UTC).Add(-time.Nanosecond),
@@ -119,6 +120,7 @@ func TestNewReports(t *testing.T) {
 		{
 			DefinitionID:           "test",
 			ServiceName:            "test",
+			MetricPrefix:           "test",
 			DataPoint:              time.Date(2022, 1, 6, 10, 0, 0, 0, time.UTC),
 			TimeFrameStartAt:       time.Date(2022, 1, 6, 8, 0, 0, 0, time.UTC),
 			TimeFrameEndAt:         time.Date(2022, 1, 6, 10, 0, 0, 0, time.UTC).Add(-time.Nanosecond),

--- a/report_test.go
+++ b/report_test.go
@@ -102,7 +102,7 @@ func TestNewReports(t *testing.T) {
 			),
 		},
 	)
-	actual := shimesaba.NewReports("test", "test", 0.05, 2*time.Hour, c)
+	actual := shimesaba.NewReports("test", "test", "test", 0.05, 2*time.Hour, c)
 	expected := []*shimesaba.Report{
 		{
 			DefinitionID:           "test",

--- a/report_test.go
+++ b/report_test.go
@@ -63,7 +63,10 @@ func TestReport(t *testing.T) {
 }
 
 func TestNewReports(t *testing.T) {
-
+	dest := &shimesaba.Destination{
+		ServiceName:  "test",
+		MetricPrefix: "test",
+	}
 	allTimeIsNoViolation := map[time.Time]bool{
 
 		time.Date(2022, 1, 6, 8, 28, 0, 0, time.UTC): true,
@@ -102,12 +105,11 @@ func TestNewReports(t *testing.T) {
 			),
 		},
 	)
-	actual := shimesaba.NewReports("test", "test", "test", 0.05, 2*time.Hour, c)
+	actual := shimesaba.NewReports("test", dest, 0.05, 2*time.Hour, c)
 	expected := []*shimesaba.Report{
 		{
 			DefinitionID:           "test",
-			ServiceName:            "test",
-			MetricPrefix:           "test",
+			Destination:            dest,
 			DataPoint:              time.Date(2022, 1, 6, 11, 0, 0, 0, time.UTC),
 			TimeFrameStartAt:       time.Date(2022, 1, 6, 9, 0, 0, 0, time.UTC),
 			TimeFrameEndAt:         time.Date(2022, 1, 6, 11, 0, 0, 0, time.UTC).Add(-time.Nanosecond),
@@ -119,8 +121,7 @@ func TestNewReports(t *testing.T) {
 		},
 		{
 			DefinitionID:           "test",
-			ServiceName:            "test",
-			MetricPrefix:           "test",
+			Destination:            dest,
 			DataPoint:              time.Date(2022, 1, 6, 10, 0, 0, 0, time.UTC),
 			TimeFrameStartAt:       time.Date(2022, 1, 6, 8, 0, 0, 0, time.UTC),
 			TimeFrameEndAt:         time.Date(2022, 1, 6, 10, 0, 0, 0, time.UTC).Add(-time.Nanosecond),

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -1,0 +1,21 @@
+required_version: ">=0.0.0"
+
+service_name:  prod
+time_frame: 28d
+calculate_interval: 1h
+error_budget_size: 40m
+
+definitions:
+  - id: external_api_availability
+    metric_prefix: external
+    objectives:
+      - alert:
+          monitor_name_suffix: api.example.com
+          monitor_type: external
+  - id: internal_api_availability
+    metric_prefix: internal
+    objectives:
+      - alert:
+          monitor_name_suffix: api.example.com
+          monitor_type: external
+

--- a/testdata/sample.yaml
+++ b/testdata/sample.yaml
@@ -8,12 +8,14 @@ error_budget_size: 40m
 definitions:
   - id: external_api_availability
     metric_prefix: external
+    metric_suffix: availability
     objectives:
       - alert:
           monitor_name_suffix: api.example.com
           monitor_type: external
   - id: internal_api_availability
     metric_prefix: internal
+    metric_suffix: availability
     objectives:
       - alert:
           monitor_name_suffix: api.example.com


### PR DESCRIPTION
Extend the way the configuration is written.

### I want to be able to specify the ErrorBudgetSize in time.

Make it possible to accept ErrorBudgetSize as a string and interpret it.
If it is specified as a percentage, such as `0.001%`, it will be interpreted as a percentage of the time_frame setting as before.
If set as `40m`, the error budget will be set for the specified time.  

### I want to be able to tuck out common settings.

This can be done with the yaml Anker, but the description becomes verbose and confusing, so I made it so that it can be bundled with common settings.

### Make it possible to specify metric prefix and suffix when posting error budgets.

There was a case where we wanted to change the name of the metric to be posted, apart from the SLO definition. In order to handle this case, the

To handle this case, the metric will be submitted as `[metric_prefix].error_budget.[metric_suffix]`.
If metric_prefix is not specified, `shimesaba` will be set as the default value as before.
If metric_suffix is not specified, the ID of the SLO definition will be used as before.
   

Translated with www.DeepL.com/Translator (free version)