### PR TITLE
Feature/v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ For example, if id is `latency` in the above configuration, the following servic
 - `api.failure_time.latency`: Time of SLO violation within the rolling window time frame (unit:minutes)
 - `api.uptime.latency`: Time that can be treated as normal operation within the time frame of the rolling window (unit:minutes)  
 
+### Manual correction feature
+
+If you enter `downtime:3m` or similar in the reason for closing an alert, the alert will be calculated as if the SLO had been violated for 3 minutes from the time it was opened.
+
+The description "3m" can be any time like `1h`, `40m`, `1h50m`, etc. as well as other settings.
+When combined with other statements, half-width spaces are required before and after the above keywords.
+
 ### Environment variable `SSMWRAP_PATHS`
 
 It incorporates [github.com/handlename/ssmwrap](https://github.com/handlename/ssmwrap) for parameter management.  

--- a/README.md
+++ b/README.md
@@ -31,46 +31,32 @@ $ brew install mashiike/tap/shimesaba
 ### as CLI command
 
 ```console
-$ shimesaba -config config.yaml -mackerel-apikey <Mackerel API Key> run
+$ shimesaba -config config.yaml -mackerel-apikey <Mackerel API Key> 
 ```
 
 ```console
 NAME:
-   shimesaba - A command line tool for tracking SLO/ErrorBudget using Mackerel as an SLI measurement service.
+   shimesaba - A commandline tool for tracking SLO/ErrorBudget using Mackerel as an SLI measurement service.
 
 USAGE:
-   shimesaba [global options] command [command options] [arguments...]
+   shimesaba -config <config file> [command options]
 
 VERSION:
    current
 
 COMMANDS:
-   dashboard  manage mackerel dashboard for SLI/SLO
-   run        run shimesaba. this is main feature
+   dashboard  manage mackerel dashboard for SLI/SLO (deprecated)
+   run        run shimesaba. this is main feature (deprecated), use no subcommand
    help, h    Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
+   --backfill value                   generate report before n point (default: 3) [$BACKFILL, $SHIMESABA_BACKFILL]
    --config value, -c value           config file path, can set multiple [$CONFIG, $SHIMESABA_CONFIG]
    --debug                            output debug log (default: false) [$SHIMESABA_DEBUG]
+   --dry-run                          report output stdout and not put mackerel (default: false) [$SHIMESABA_DRY_RUN]
    --mackerel-apikey value, -k value  for access mackerel API (default: *********) [$MACKEREL_APIKEY, $SHIMESABA_MACKEREL_APIKEY]
    --help, -h                         show help (default: false)
    --version, -v                      print the version (default: false)
-2021/11/14 23:29:45 [error] Required flag "config" not set
-```
-
-run command usage is follow
-```console
-$ shimesaba run --help
-NAME:
-   main run - run shimesaba. this is main feature
-
-USAGE:
-   shimesaba -config <config file> run [command options]
-
-OPTIONS:
-   --dry-run         report output stdout and not put mackerel (default: false) [$SHIMESABA_DRY_RUN]
-   --backfill value  generate report before n point (default: 3) [$BACKFILL, $SHIMESABA_BACKFILL]
-   --help, -h        show help (default: false)
 ```
 
 ### as AWS Lambda function
@@ -102,169 +88,52 @@ Example Lambda functions configuration.
 
 ### Configuration file
 
+The following are the settings for the latest v0.7.0.
+
 YAML format.
 
 ```yaml
-required_version: ">=0.0.0"
+required_version: ">=0.7.0" # which specifies which versions of shimesaba can be used with your configuration.
 
-metrics:
-  - id: alb_p90_response_time
-    name: custom.alb.response.time_p90
-    type: host
-    service_name: prod
-    host_name: dummy-alb
-    aggregation_interval: 1m
-    aggregation_method: max
-  - id: component_response_time
-    name: component.dummy.response_time
-    type: service
-    service_name: prod
-    aggregation_interval: 1m
-    aggregation_method: avg
+# This is a common setting item for error budget calculation.
+# It is possible to override the same settings in each SLO definition.
+service_name: prod          # - The name of the service to which you want to submit the service metric for error budgeting.
+metric_prefix: api          # - Specifies the service metric prefix for error budgeting.
+time_frame: 28d             # - Specify the size of the rolling window to calculate the error budget.
+calculate_interval: 1h      # - Settings related to the interval for calculating the error budget.
+error_budget_size: 0.1%     # - This setting is related to the size of the error budget.
+                            #   If % is used, it is a ratio to the size of the rolling window.
+                            #   It is also possible to specify a time such as 1h or 40m.
 
+# Describes the settings for each SLO. SLOs are treated as monitoring rules.
+# The definition of each SLO is determined by ORing the monitoring rules that match the conditions specified in `objectives`.
+# That is, based on the alerts corresponding to the monitoring rules that match the conditions, the existence of any of the alerts will be judged as SLO violation.
 definitions:
+  # In the availability SLO, if an alert occurs for a monitoring rule name that starts with "SLO availability" 
+  #  or an external monitoring rule that ends with "api.example.com", it is considered an SLO violation. 
+  - id: availability
+    objectives: 
+      - monitor_name_prefix: "SLO availability"
+      - monitor_name_suffix: "api.example.com"
+        monitor_type: "external" 
+  # In the latency SLO, we consider it an SLO violation if an alert occurs for a host metric monitoring rule with a name starting with "SLO availability".
   - id: latency
-    service_name: prod 
-    time_frame: 28d #4weeks
-    calculate_interval: 1h
-    error_budget_size: 0.001
+    error_budget_size: 200m
     objectives:
-      - expr: alb_p90_response_time <= 1.0
-      - expr: component_response_time <= 1.0
-
-dashboard: dashboard.jsonnet
+      - monitor_name_prefix: "SLO latency"
+      - monitor_type: "host"
 ```
 
-#### required_version
+`definitions` takes a list of constituent SLI/SLO definitions.  
+6 Mackerel service metrics will be listed per definition. 
 
- the `required_version` accepts a version constraint string, which specifies which versions of shimesaba can be used with your configuration.
-
-#### metrics
-
-The `metrics` accepts list of Mackerel metrics configure.  
-`shimesaba` gets the mackerel metric specified in this list.   
-The metrics described in this list can be found in the `definitions` settings described below.
-Each setting item in the list is as follows
-
-##### id 
-
-Required.  
-An identifier to refer to in `definitions`.
-Must be unique in the list
-
-##### name 
-
-Required.  
-Metric identifier on Mackerel
-
-##### type 
-
-Required.  
-The type of metric. Host metric must set `host` and service metric must set` service`.
-
-##### service_name
-
-Required.  
-Specify the name of the service to which the metric belongs
-
-##### roles
-
-Optional, only type=`host`  
-Specifies the role when searching for hosts that are subject to host metrics.
-
-##### host_name
-
-Optional, only type=`host`  
-Specify the host name when searching for the host that is the target of host metrics.
-
-##### aggregation_interval
-
-Optional, default=1m
-It's time to aggregate the metrics.
-This is also the unit for determining SLO violations.
-For example, if you calculate SLI using a metric with an aggregation interval of 5 minutes, you will get an SLO violation check in 5 minute increments.
-
-##### aggregation_method
-
-Optional, default=max
-How to aggregate metrics. There are `max`,` total`, `avg`.
-
-##### interpolated_value
-
-Optional
-Specifies the value to interpolate if the data point is missing.
-If not specified, it will be treated as nil in the expression.
-
-#### definitions
-
-The `definitions` accepts list of SLI/SLO definition configure.   
-6 Mackerel service metrics are posted per definition.  
-
-For example, if id is `latency`, the following service metric will be posted.
-- `shimesaba.error_budget.latency`: Current error budget remaining number (unit:minutes)
-- `shimesaba.error_budget_percentage.latency`: percentage of current error budget remaining. If it exceeds 100%, the error budget is used up.
-- `shimesaba.error_budget_consumption.latency`: Error budget newly consumed in this calculation window (unit:minutes)
-- `shimesaba.error_budget_consumption_percentage.latency`: Percentage of newly consumed error budget in this calculation window 
-- `shimesaba.failure_time.latency`: Time of SLO violation within the rolling window time frame (unit:minutes)
-- `shimesaba.uptime.latency`: Time that can be treated as normal operation within the time frame of the rolling window (unit:minutes)  
-
-Each setting item in the list is as follows  
-
-##### id 
-
-Required.  
-The identifier of `definition`. Based on this identifier, the service metric masterpiece at the time of posting is determined.  
-Must be unique in the list.
-
-##### service_name
-
-Required.  
-The service to which the service metric is posted
-
-##### time_frame
-
-Required. 
-The size of the time frame of the rolling window.  
-For example, if you specify 40320 minutes, the error budget will be calculated for the SLI for the last 4 weeks.  
-
-##### calculate_interval
-
-Required.  
-
-The shift width of the rolling window. Service metrics are posted to Mackerel at individually specified time intervals.  
-This width is recommended to be shorter than 1440 minutes (1 day) because Mackerel ignores postings of time stamp metrics before 24 hours *1.  
-
-*1 [https://mackerel.io/ja/api-docs/entry/service-metrics#post](https://mackerel.io/ja/api-docs/entry/service-metrics#post)
-
-We recommend running shimesaba every hour with `calculate_interval` set to 60 minutes (1 hour).
-
-##### error_budget_size:
-
-Required.  
-Setting how much error budget should be taken with respect to the width of the time frame of the rolling window.
-For example, if `time_frame` is 40320 and you specify 0.001 (0.1%), the size of the error budget will be 40 minutes.
-This means that we will tolerate SLO violations of up to 40 minutes in the last 4 weeks.
-
-##### objectives
-
-Required.  
-A list of specific SLO definitions.
-This is a list of expr.
-`expr` defines a Go syntax comparison expression.
-You can use the `id` specified in `metrics` like a variable.
-The right-hand side of the comparison must always be a numeric literal.
-If multiple expr are defined in the objectives, all must be true.
-If any of expr are false, it is a violation of SLO.
-
-For example:   
-Assuming that you have obtained the metrics `alb_2xx` and `alb_5xx`, you can write the following comparison formula.
-
-```yaml
-- expr: rate(alb_2xx, alb_2xx + alb_5xx) >= 0.95
-```
-
-`rate()` is a function prepared to safely execute division while avoiding division by zero.
-The meaning of this comparison formula is `If the HTTP request rate is 95% or higher, the service is healthy`.
+For example, if id is `latency` in the above configuration, the following service metric will be posted.
+- `api.error_budget.latency`: Current error budget remaining number (unit:minutes)
+- `api.error_budget_percentage.latency`: percentage of current error budget remaining. If it exceeds 100%, the error budget is used up.
+- `api.error_budget_consumption.latency`: Error budget newly consumed in this calculation window (unit:minutes)
+- `api.error_budget_consumption_percentage.latency`: Percentage of newly consumed error budget in this calculation window 
+- `api.failure_time.latency`: Time of SLO violation within the rolling window time frame (unit:minutes)
+- `api.uptime.latency`: Time that can be treated as normal operation within the time frame of the rolling window (unit:minutes)  
 
 ### Environment variable `SSMWRAP_PATHS`
 
@@ -272,70 +141,14 @@ It incorporates [github.com/handlename/ssmwrap](https://github.com/handlename/ss
 If you specify the path of the Parameter Store of AWS Systems Manager separated by commas, it will be output to the environment variable.  
 Useful when used as a Lambda function.  
 
-### Usage Dashboard subcommand.
+### Environment variable `SHIMESABA_ENABLE_REASSESSMENT`
 
-This subcommand can only be used when acting as a CLI.  
-If the dashboard of the config file contains the dashboard definition file, you can manage the dashboard JSON using Go Template.
+Activate experimental features.
+This will re-evaluate the SLO based on the current monitoring rules for host metric monitoring and service metric monitoring, going back from 15 minutes before the specified alert period.
 
-For example, you can build a simple dashboard by defining a json file like the one below.
+This experimental feature is to avoid the problem of the minimum error budget consumption unit of 5 minutes when evaluating monitoring rules every 5 minutes in AWS Integration, etc.
 
-dashboard.jsonnet
-```jsonnet
-local errorBudgetCounter(x, y, def_id, title) = {
-  type: 'value',
-  title: title,
-  layout: {
-    x: x,
-    y: y,
-    width: 10,
-    height: 5,
-  },
-  metric: {
-    type: 'service',
-    name: 'shimesaba.error_budget.' + def_id,
-    serviceName: 'shimesaba',
-  },
-  graph: null,
-  range: null,
-  fractionSize: 0,
-  suffix: 'min',
-};
-{
-  title: 'SLI/SLO',
-  urlPath: '4oequPJEwwd',
-  memo: '',
-  widgets: [
-    errorBudgetCounter(0, 0, 'availability', ''),
-    errorBudgetCounter(10, 0, 'latency', ''),
-    {
-      type: 'markdown',
-      title: 'SLO Definitions',
-      layout: {
-        x: 20,
-        y: 0,
-        width: 5,
-        height: 20,
-      },
-      markdown: '{{file `definitions.md` | json_escape }}',
-    },
-  ],
-}
-```
-
-definitions.md
-```markdown
-{{ range $def_id, $def := .Definitions }}
-## SLO {{ $def_id }}
-
-- TimeFrame      : {{ $def.TimeFrame }}
-- ErrorBudgetSize: {{ $def.ErrorBudgetSizeDuration }}  
-
-
-{{ range $def.Objectives }}
-- {{ . }}
-{{ end }}
-{{ end }}
-```
+Translated with www.DeepL.com/Translator (free version)
 
 ## LICENSE
 

--- a/alert.go
+++ b/alert.go
@@ -28,8 +28,8 @@ func NewAlert(monitor *Monitor, openedAt time.Time, closedAt *time.Time) *Alert 
 
 func (alert *Alert) String() string {
 	return fmt.Sprintf("alert[%s:%s] %s ~ %s",
-		alert.Monitor.ID,
-		alert.Monitor.Name,
+		alert.Monitor.ID(),
+		alert.Monitor.Name(),
 		alert.OpenedAt,
 		alert.ClosedAt,
 	)

--- a/alert.go
+++ b/alert.go
@@ -35,7 +35,7 @@ func (alert *Alert) String() string {
 	)
 }
 
-func (alert *Alert) NewReliabilityCollection(timeFrame time.Duration) (ReliabilityCollection, error) {
+func (alert *Alert) NewReliabilities(timeFrame time.Duration) (Reliabilities, error) {
 	isNoViolation, startAt, endAt := alert.newIsNoViolation()
 	startAt = startAt.Truncate(timeFrame)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
@@ -44,7 +44,7 @@ func (alert *Alert) NewReliabilityCollection(timeFrame time.Duration) (Reliabili
 		cursorAt, _ := iter.Next()
 		reliabilitySlice = append(reliabilitySlice, NewReliability(cursorAt, timeFrame, isNoViolation))
 	}
-	return NewReliabilityCollection(reliabilitySlice)
+	return NewReliabilities(reliabilitySlice)
 }
 
 func (alert *Alert) newIsNoViolation() (isNoViolation map[time.Time]bool, startAt, endAt time.Time) {

--- a/alert.go
+++ b/alert.go
@@ -35,7 +35,7 @@ func (alert *Alert) String() string {
 	)
 }
 
-func (alert *Alert) NewReliabilities(timeFrame time.Duration) (Reliabilities, error) {
+func (alert *Alert) CalculateReliabilities(timeFrame time.Duration) (Reliabilities, error) {
 	isNoViolation, startAt, endAt := alert.newIsNoViolation()
 	startAt = startAt.Truncate(timeFrame)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -16,7 +16,7 @@ func NewAlertObjective(cfg *AlertObjectiveConfig) *AlertObjective {
 	return &AlertObjective{cfg: cfg}
 }
 
-func (o AlertObjective) NewReliabilities(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (Reliabilities, error) {
+func (o AlertObjective) CalculateReliabilities(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (Reliabilities, error) {
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)
 	rc := make([]*Reliability, 0)
@@ -32,7 +32,7 @@ func (o AlertObjective) NewReliabilities(timeFrame time.Duration, alerts Alerts,
 		if !o.matchAlert(alert) {
 			continue
 		}
-		tmp, err := alert.NewReliabilities(timeFrame)
+		tmp, err := alert.CalculateReliabilities(timeFrame)
 		if err != nil {
 			return nil, err
 		}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -55,22 +55,22 @@ func (o AlertObjective) matchAlert(alert *Alert) bool {
 
 func (o AlertObjective) MatchMonitor(monitor *Monitor) bool {
 	if o.cfg.MonitorID != "" {
-		if monitor.ID != o.cfg.MonitorID {
+		if monitor.ID() != o.cfg.MonitorID {
 			return false
 		}
 	}
 	if o.cfg.MonitorNamePrefix != "" {
-		if !strings.HasPrefix(monitor.Name, o.cfg.MonitorNamePrefix) {
+		if !strings.HasPrefix(monitor.Name(), o.cfg.MonitorNamePrefix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorNameSuffix != "" {
-		if !strings.HasSuffix(monitor.Name, o.cfg.MonitorNameSuffix) {
+		if !strings.HasSuffix(monitor.Name(), o.cfg.MonitorNameSuffix) {
 			return false
 		}
 	}
 	if o.cfg.MonitorType != "" {
-		if !strings.EqualFold(monitor.Type, o.cfg.MonitorType) {
+		if !strings.EqualFold(monitor.Type(), o.cfg.MonitorType) {
 			return false
 		}
 	}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -16,7 +16,7 @@ func NewAlertObjective(cfg *AlertObjectiveConfig) *AlertObjective {
 	return &AlertObjective{cfg: cfg}
 }
 
-func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (ReliabilityCollection, error) {
+func (o AlertObjective) NewReliabilities(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (Reliabilities, error) {
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)
 	rc := make([]*Reliability, 0)
@@ -24,7 +24,7 @@ func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts
 		cursorAt, _ := iter.Next()
 		rc = append(rc, NewReliability(cursorAt, timeFrame, nil))
 	}
-	reliabilities, err := NewReliabilityCollection(rc)
+	reliabilities, err := NewReliabilities(rc)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (o AlertObjective) NewReliabilityCollection(timeFrame time.Duration, alerts
 		if !o.matchAlert(alert) {
 			continue
 		}
-		tmp, err := alert.NewReliabilityCollection(timeFrame)
+		tmp, err := alert.NewReliabilities(timeFrame)
 		if err != nil {
 			return nil, err
 		}

--- a/alert_objective.go
+++ b/alert_objective.go
@@ -16,7 +16,7 @@ func NewAlertObjective(cfg *AlertObjectiveConfig) *AlertObjective {
 	return &AlertObjective{cfg: cfg}
 }
 
-func (o AlertObjective) CalculateReliabilities(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (Reliabilities, error) {
+func (o AlertObjective) EvaluateReliabilities(timeFrame time.Duration, alerts Alerts, startAt, endAt time.Time) (Reliabilities, error) {
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)
 	rc := make([]*Reliability, 0)
@@ -32,7 +32,7 @@ func (o AlertObjective) CalculateReliabilities(timeFrame time.Duration, alerts A
 		if !o.matchAlert(alert) {
 			continue
 		}
-		tmp, err := alert.CalculateReliabilities(timeFrame)
+		tmp, err := alert.EvaluateReliabilities(timeFrame)
 		if err != nil {
 			return nil, err
 		}

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -126,14 +126,14 @@ func TestAlertObjective(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
 			obj := shimesaba.NewAlertObjective(c.cfg)
-			actual, err := obj.NewReliabilityCollection(
+			actual, err := obj.NewReliabilities(
 				time.Minute,
 				alerts,
 				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
 				time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
 			)
 			require.NoError(t, err)
-			expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+			expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -15,38 +15,38 @@ func TestAlertObjective(t *testing.T) {
 	defer restore()
 	alerts := shimesaba.Alerts{
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID:   "hogera",
-				Name: "SLO hoge",
-				Type: "expression",
-			},
+			shimesaba.NewMonitor(
+				"hogera",
+				"SLO hoge",
+				"expression",
+			),
 			time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID:   "fugara",
-				Name: "SLO fuga",
-				Type: "service",
-			},
+			shimesaba.NewMonitor(
+				"fugara",
+				"SLO fuga",
+				"service",
+			),
 			time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID:   "fugara",
-				Name: "SLO fuga",
-				Type: "service",
-			},
+			shimesaba.NewMonitor(
+				"fugara",
+				"SLO fuga",
+				"service",
+			),
 			time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID:   "hogera",
-				Name: "SLO hoge",
-				Type: "expression",
-			},
+			shimesaba.NewMonitor(
+				"hogera",
+				"SLO hoge",
+				"expression",
+			),
 			time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC),
 			nil,
 		),

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -126,7 +126,7 @@ func TestAlertObjective(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
 			obj := shimesaba.NewAlertObjective(c.cfg)
-			actual, err := obj.NewReliabilities(
+			actual, err := obj.CalculateReliabilities(
 				time.Minute,
 				alerts,
 				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),

--- a/alert_objective_test.go
+++ b/alert_objective_test.go
@@ -126,7 +126,7 @@ func TestAlertObjective(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
 			obj := shimesaba.NewAlertObjective(c.cfg)
-			actual, err := obj.CalculateReliabilities(
+			actual, err := obj.EvaluateReliabilities(
 				time.Minute,
 				alerts,
 				time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),

--- a/alert_test.go
+++ b/alert_test.go
@@ -176,6 +176,26 @@ func TestAlertEvaluateReliabilities(t *testing.T) {
 				shimesaba.NewMonitor(
 					"fugara",
 					"fugara.example.com",
+					"external",
+				),
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+				ptrTime(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC)),
+			).WithReason("downtime:0m"),
+			timeFrame: 5 * time.Minute,
+			expectedGenerator: func() shimesaba.Reliabilities {
+				isNoViolation := map[time.Time]bool{}
+				expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
+				})
+				return expected
+			},
+		},
+		{
+			alert: shimesaba.NewAlert(
+				shimesaba.NewMonitor(
+					"fugara",
+					"fugara.example.com",
 					"service",
 				).WithEvaluator(func(hostID string, timeFrame time.Duration, startAt, endAt time.Time) (shimesaba.Reliabilities, bool) {
 					isNoViolation := map[time.Time]bool{

--- a/alert_test.go
+++ b/alert_test.go
@@ -49,7 +49,7 @@ func TestAlerts(t *testing.T) {
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
 }
 
-func TestAlertNewReliabilities(t *testing.T) {
+func TestAlertCalculateReliabilities(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC))
 	defer restore()
 	cases := []struct {
@@ -132,7 +132,7 @@ func TestAlertNewReliabilities(t *testing.T) {
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
-			actual, err := c.alert.NewReliabilities(c.timeFrame)
+			actual, err := c.alert.CalculateReliabilities(c.timeFrame)
 			require.NoError(t, err)
 			require.EqualValues(t, c.expectedGenerator(), actual)
 		})

--- a/alert_test.go
+++ b/alert_test.go
@@ -15,23 +15,29 @@ func TestAlerts(t *testing.T) {
 	defer restore()
 	alerts := shimesaba.Alerts{
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID: "hogera",
-			},
+			shimesaba.NewMonitor(
+				"hogera",
+				"hogera.example.com",
+				"external",
+			),
 			time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID: "fugara",
-			},
+			shimesaba.NewMonitor(
+				"fugara",
+				"fugara.example.com",
+				"external",
+			),
 			time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID: "fugara",
-			},
+			shimesaba.NewMonitor(
+				"fugara",
+				"fugara.example.com",
+				"external",
+			),
 			time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 		),
@@ -39,9 +45,11 @@ func TestAlerts(t *testing.T) {
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), alerts.EndAt())
 	alerts = append(alerts, shimesaba.NewAlert(
-		&shimesaba.Monitor{
-			ID: "hogera",
-		},
+		shimesaba.NewMonitor(
+			"hogera",
+			"hogera.example.com",
+			"external",
+		),
 		time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC),
 		nil,
 	))
@@ -59,9 +67,11 @@ func TestAlertCalculateReliabilities(t *testing.T) {
 	}{
 		{
 			alert: shimesaba.NewAlert(
-				&shimesaba.Monitor{
-					ID: "fugara",
-				},
+				shimesaba.NewMonitor(
+					"fugara",
+					"fugara.example.com",
+					"external",
+				),
 				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 				ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 			),
@@ -79,9 +89,11 @@ func TestAlertCalculateReliabilities(t *testing.T) {
 		},
 		{
 			alert: shimesaba.NewAlert(
-				&shimesaba.Monitor{
-					ID: "fugara",
-				},
+				shimesaba.NewMonitor(
+					"fugara",
+					"fugara.example.com",
+					"external",
+				),
 				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 				ptrTime(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC)),
 			),
@@ -103,9 +115,11 @@ func TestAlertCalculateReliabilities(t *testing.T) {
 		},
 		{
 			alert: shimesaba.NewAlert(
-				&shimesaba.Monitor{
-					ID: "fugara",
-				},
+				shimesaba.NewMonitor(
+					"fugara",
+					"fugara.example.com",
+					"external",
+				),
 				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 				nil,
 			),

--- a/alert_test.go
+++ b/alert_test.go
@@ -57,7 +57,7 @@ func TestAlerts(t *testing.T) {
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
 }
 
-func TestAlertCalculateReliabilities(t *testing.T) {
+func TestAlertEvaluateReliabilities(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC))
 	defer restore()
 	cases := []struct {
@@ -146,7 +146,7 @@ func TestAlertCalculateReliabilities(t *testing.T) {
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
-			actual, err := c.alert.CalculateReliabilities(c.timeFrame)
+			actual, err := c.alert.EvaluateReliabilities(c.timeFrame)
 			require.NoError(t, err)
 			require.EqualValues(t, c.expectedGenerator(), actual)
 		})

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,6 +1,7 @@
 package shimesaba_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -46,4 +47,94 @@ func TestAlerts(t *testing.T) {
 	))
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
+}
+
+func TestAlertNewReliabilityCollection(t *testing.T) {
+	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC))
+	defer restore()
+	cases := []struct {
+		alert             *shimesaba.Alert
+		timeFrame         time.Duration
+		expectedGenerator func() shimesaba.ReliabilityCollection
+	}{
+		{
+			alert: shimesaba.NewAlert(
+				&shimesaba.Monitor{
+					ID: "fugara",
+				},
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+				ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
+			),
+			timeFrame: 5 * time.Minute,
+			expectedGenerator: func() shimesaba.ReliabilityCollection {
+				isNoViolation := map[time.Time]bool{
+					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
+				}
+				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
+				})
+				return expected
+			},
+		},
+		{
+			alert: shimesaba.NewAlert(
+				&shimesaba.Monitor{
+					ID: "fugara",
+				},
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+				ptrTime(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC)),
+			),
+			timeFrame: 5 * time.Minute,
+			expectedGenerator: func() shimesaba.ReliabilityCollection {
+				isNoViolation := map[time.Time]bool{
+					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 7, 0, 0, time.UTC): false,
+				}
+				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
+				})
+				return expected
+			},
+		},
+		{
+			alert: shimesaba.NewAlert(
+				&shimesaba.Monitor{
+					ID: "fugara",
+				},
+				time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
+				nil,
+			),
+			timeFrame: 2 * time.Minute,
+			expectedGenerator: func() shimesaba.ReliabilityCollection {
+				isNoViolation := map[time.Time]bool{
+					time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): true,
+					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 7, 0, 0, time.UTC): false,
+					time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC): false,
+				}
+				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
+					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
+				})
+				return expected
+			},
+		},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
+			actual, err := c.alert.NewReliabilityCollection(c.timeFrame)
+			require.NoError(t, err)
+			require.EqualValues(t, c.expectedGenerator(), actual)
+		})
+	}
 }

--- a/alert_test.go
+++ b/alert_test.go
@@ -49,13 +49,13 @@ func TestAlerts(t *testing.T) {
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), alerts.EndAt())
 }
 
-func TestAlertNewReliabilityCollection(t *testing.T) {
+func TestAlertNewReliabilities(t *testing.T) {
 	restore := flextime.Fix(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC))
 	defer restore()
 	cases := []struct {
 		alert             *shimesaba.Alert
 		timeFrame         time.Duration
-		expectedGenerator func() shimesaba.ReliabilityCollection
+		expectedGenerator func() shimesaba.Reliabilities
 	}{
 		{
 			alert: shimesaba.NewAlert(
@@ -66,12 +66,12 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 				ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 			),
 			timeFrame: 5 * time.Minute,
-			expectedGenerator: func() shimesaba.ReliabilityCollection {
+			expectedGenerator: func() shimesaba.Reliabilities {
 				isNoViolation := map[time.Time]bool{
 					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
 					time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
 				}
-				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+				expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
 				})
 				return expected
@@ -86,7 +86,7 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 				ptrTime(time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC)),
 			),
 			timeFrame: 5 * time.Minute,
-			expectedGenerator: func() shimesaba.ReliabilityCollection {
+			expectedGenerator: func() shimesaba.Reliabilities {
 				isNoViolation := map[time.Time]bool{
 					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
 					time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC): false,
@@ -94,7 +94,7 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 					time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC): false,
 					time.Date(2021, time.October, 1, 0, 7, 0, 0, time.UTC): false,
 				}
-				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+				expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), 5*time.Minute, isNoViolation),
 				})
@@ -110,7 +110,7 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 				nil,
 			),
 			timeFrame: 2 * time.Minute,
-			expectedGenerator: func() shimesaba.ReliabilityCollection {
+			expectedGenerator: func() shimesaba.Reliabilities {
 				isNoViolation := map[time.Time]bool{
 					time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC): true,
 					time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC): false,
@@ -120,7 +120,7 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 					time.Date(2021, time.October, 1, 0, 7, 0, 0, time.UTC): false,
 					time.Date(2021, time.October, 1, 0, 8, 0, 0, time.UTC): false,
 				}
-				expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+				expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
 					shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 6, 0, 0, time.UTC), 2*time.Minute, isNoViolation),
@@ -132,7 +132,7 @@ func TestAlertNewReliabilityCollection(t *testing.T) {
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case.%d", i), func(t *testing.T) {
-			actual, err := c.alert.NewReliabilityCollection(c.timeFrame)
+			actual, err := c.alert.NewReliabilities(c.timeFrame)
 			require.NoError(t, err)
 			require.EqualValues(t, c.expectedGenerator(), actual)
 		})

--- a/app.go
+++ b/app.go
@@ -43,7 +43,11 @@ func NewWithMackerelClient(client MackerelClient, cfg *Config) (*App, error) {
 
 //Run performs the calculation of the error bar calculation
 func (app *App) Run(ctx context.Context, optFns ...func(*Options)) error {
-	log.Printf("[info] start run")
+	orgName, err := app.repo.GetOrgName(ctx)
+	if err != nil {
+		return err
+	}
+	log.Printf("[info] start run in the `%s` organization.", orgName)
 	opts := &Options{
 		backfill: 3,
 		dryRun:   false,

--- a/app.go
+++ b/app.go
@@ -54,7 +54,7 @@ func (app *App) Run(ctx context.Context, optFns ...func(*Options)) error {
 
 	repo := app.repo
 	if opts.dryRun {
-		log.Println("[warn] **with dry run**")
+		log.Println("[notice] **with dry run**")
 		repo = repo.WithDryRun()
 	}
 

--- a/app_test.go
+++ b/app_test.go
@@ -112,6 +112,12 @@ func newMockMackerelClient(t *testing.T) *mockMackerelClient {
 	}
 }
 
+func (m *mockMackerelClient) GetOrg() (*mackerel.Org, error) {
+	return &mackerel.Org{
+		Name: "dummy",
+	}, nil
+}
+
 func (m *mockMackerelClient) FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error) {
 	require.EqualValues(
 		m.t,

--- a/cmd/shimesaba/main.go
+++ b/cmd/shimesaba/main.go
@@ -19,8 +19,10 @@ import (
 )
 
 var (
-	Version    = "current"
-	ssmwrapErr error
+	Version        = "current"
+	ssmwrapErr     error
+	legacyDryRun   bool
+	legacyBackfill int
 )
 
 func main() {
@@ -54,42 +56,42 @@ func main() {
 				Usage:   "output debug log",
 				EnvVars: []string{"SHIMESABA_DEBUG"},
 			},
+			&cli.BoolFlag{
+				Name:    "dry-run",
+				Usage:   "report output stdout and not put mackerel",
+				EnvVars: []string{"SHIMESABA_DRY_RUN"},
+			},
+			&cli.IntFlag{
+				Name:        "backfill",
+				DefaultText: "3",
+				Value:       3,
+				Usage:       "generate report before n point",
+				EnvVars:     []string{"BACKFILL", "SHIMESABA_BACKFILL"},
+			},
 		},
+		Action: run,
 		Commands: []*cli.Command{
 			{
 				Name:      "run",
 				Usage:     "run shimesaba. this is main feature",
 				UsageText: "shimesaba -config <config file> run [command options]",
 				Action: func(c *cli.Context) error {
-					app, err := buildApp(c)
-					if err != nil {
-						return err
-					}
-					optFns := []func(*shimesaba.Options){
-						shimesaba.DryRunOption(c.Bool("dry-run")),
-						shimesaba.BackfillOption(c.Int("backfill")),
-					}
-					handler := func(ctx context.Context) error {
-						return app.Run(ctx, optFns...)
-					}
-					if isLambda() {
-						lambda.Start(handler)
-						return nil
-					}
-					return handler(c.Context)
+					log.Println("[warn] subcommand `run` is deprecated. no use subcommand.")
+					return run(c)
 				},
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:    "dry-run",
-						Usage:   "report output stdout and not put mackerel",
-						EnvVars: []string{"SHIMESABA_DRY_RUN"},
+						Name:        "dry-run",
+						Usage:       "report output stdout and not put mackerel",
+						EnvVars:     []string{"SHIMESABA_DRY_RUN"},
+						Destination: &legacyDryRun,
 					},
 					&cli.IntFlag{
 						Name:        "backfill",
 						DefaultText: "3",
-						Value:       3,
 						Usage:       "generate report before n point",
 						EnvVars:     []string{"BACKFILL", "SHIMESABA_BACKFILL"},
+						Destination: &legacyBackfill,
 					},
 				},
 			},
@@ -102,6 +104,7 @@ func main() {
 						Usage:     "import an existing mackerel dashboard",
 						UsageText: "shimesaba dashboard [global options] init <dashboard_id or dashboard_url_path>",
 						Action: func(c *cli.Context) error {
+							log.Println("[warn] subcommand `dashboard init` is deprecated.")
 							if c.NArg() < 1 {
 								cli.ShowAppHelp(c)
 								return errors.New("dashboard_id is required")
@@ -118,6 +121,7 @@ func main() {
 						Usage:     "create or update mackerel dashboard",
 						UsageText: "shimesaba dashboard [global options] build",
 						Action: func(c *cli.Context) error {
+							log.Println("[warn] subcommand `dashboard build` is deprecated.")
 							app, err := buildApp(c)
 							if err != nil {
 								return err
@@ -178,4 +182,27 @@ func buildApp(c *cli.Context) (*shimesaba.App, error) {
 		return nil, err
 	}
 	return shimesaba.New(c.String("mackerel-apikey"), cfg)
+}
+
+func run(c *cli.Context) error {
+	app, err := buildApp(c)
+	if err != nil {
+		return err
+	}
+	backfill := c.Int("backfill")
+	if legacyBackfill > 0 {
+		backfill = legacyBackfill
+	}
+	optFns := []func(*shimesaba.Options){
+		shimesaba.DryRunOption(c.Bool("dry-run") || legacyDryRun),
+		shimesaba.BackfillOption(backfill),
+	}
+	handler := func(ctx context.Context) error {
+		return app.Run(ctx, optFns...)
+	}
+	if isLambda() {
+		lambda.Start(handler)
+		return nil
+	}
+	return handler(c.Context)
 }

--- a/cmd/shimesaba/main.go
+++ b/cmd/shimesaba/main.go
@@ -35,8 +35,9 @@ func main() {
 		})
 	}
 	cliApp := &cli.App{
-		Name:  "shimesaba",
-		Usage: "A commandline tool for tracking SLO/ErrorBudget using Mackerel as an SLI measurement service.",
+		Name:      "shimesaba",
+		Usage:     "A commandline tool for tracking SLO/ErrorBudget using Mackerel as an SLI measurement service.",
+		UsageText: "shimesaba -config <config file> [command options]",
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
 				Name:    "config",
@@ -73,7 +74,7 @@ func main() {
 		Commands: []*cli.Command{
 			{
 				Name:      "run",
-				Usage:     "run shimesaba. this is main feature",
+				Usage:     "run shimesaba. this is main feature (deprecated), use no subcommand",
 				UsageText: "shimesaba -config <config file> run [command options]",
 				Action: func(c *cli.Context) error {
 					log.Println("[warn] subcommand `run` is deprecated. no use subcommand.")
@@ -97,11 +98,11 @@ func main() {
 			},
 			{
 				Name:  "dashboard",
-				Usage: "manage mackerel dashboard for SLI/SLO",
+				Usage: "manage mackerel dashboard for SLI/SLO (deprecated)",
 				Subcommands: []*cli.Command{
 					{
 						Name:      "init",
-						Usage:     "import an existing mackerel dashboard",
+						Usage:     "import an existing mackerel dashboard (deprecated)",
 						UsageText: "shimesaba dashboard [global options] init <dashboard_id or dashboard_url_path>",
 						Action: func(c *cli.Context) error {
 							log.Println("[warn] subcommand `dashboard init` is deprecated.")
@@ -118,7 +119,7 @@ func main() {
 					},
 					{
 						Name:      "build",
-						Usage:     "create or update mackerel dashboard",
+						Usage:     "create or update mackerel dashboard (deprecated)",
 						UsageText: "shimesaba dashboard [global options] build",
 						Action: func(c *cli.Context) error {
 							log.Println("[warn] subcommand `dashboard build` is deprecated.")

--- a/config.go
+++ b/config.go
@@ -314,27 +314,36 @@ func (c *DefinitionConfig) StartAt(now time.Time, backfill int) time.Time {
 
 // Objective Config is a SLO setting
 type ObjectiveConfig struct {
-	Expr  string                `yaml:"expr" json:"expr"`
-	Alert *AlertObjectiveConfig `yaml:"alert" json:"alert"`
+	Expr                 string                `yaml:"expr" json:"expr"`
+	Alert                *AlertObjectiveConfig `yaml:"alert" json:"alert"`
+	AlertObjectiveConfig `yaml:",inline"`
 
 	comparator evaluator.Comparator
 }
 
 // Restrict restricts a configuration.
 func (c *ObjectiveConfig) Restrict() error {
+	globalErr := c.AlertObjectiveConfig.Restrict()
+	if globalErr == nil {
+		c.Alert = &c.AlertObjectiveConfig
+		return nil
+	}
+	log.Println("[warn] this objective config is deprecated and will not be available starting from v0.8.0.")
 	if c.Expr == "" && c.Alert == nil {
-		return errors.New("either expr or alert is required")
+		return errors.New("alert config is required")
 	}
 	if c.Expr != "" && c.Alert != nil {
 		return errors.New("only one of expr or alert can be set")
 	}
 	if c.Expr != "" {
+		log.Println("[warn] the Objective feature with `expr` will not be available after v0.8.0, please set up an equivalent monitor on Mackerel to use the Objective feature with alerts.")
 		return c.buildComparator()
 	}
 	if c.Alert != nil {
+		log.Println("[warn] Since v0.8.0, the `expr` objective feature will be removed, so the key `alert` will no longer be needed.")
 		return c.Alert.Restrict()
 	}
-	return errors.New("unexpected config")
+	return globalErr
 }
 
 func (c *ObjectiveConfig) buildComparator() error {
@@ -476,10 +485,12 @@ func (c *Config) Restrict() error {
 		}
 		c.versionConstraints = constraints
 	}
-	if err := c.Metrics.Restrict(); err != nil {
-		return fmt.Errorf("metrics has invalid: %w", err)
+	if len(c.Metrics) > 0 {
+		log.Println("[warn] Since v0.8.0, the setting `metrics` is no longer necessary because the expr function will be removed. This setting is deprecated.")
+		if err := c.Metrics.Restrict(); err != nil {
+			return fmt.Errorf("metrics has invalid: %w", err)
+		}
 	}
-
 	for id, cfg := range c.Definitions {
 		base := &DefinitionConfig{
 			TimeFrame:         c.TimeFrame,

--- a/config.go
+++ b/config.go
@@ -505,6 +505,9 @@ func (c *Config) Restrict() error {
 	if err := c.Definitions.Restrict(); err != nil {
 		return fmt.Errorf("definitions has invalid: %w", err)
 	}
+	if c.Dashboard != "" {
+		log.Printf("[warn] Use of the dashboard management feature is deprecated; we plan to remove this feature after v0.8.0.")
+	}
 
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -35,6 +35,10 @@ func TestConfigLoadNoError(t *testing.T) {
 			casename: "sample_config",
 			paths:    []string{"testdata/sample.yaml"},
 		},
+		{
+			casename: "v0.7.0 over",
+			paths:    []string{"testdata/v0.7.0.yaml"},
+		},
 	}
 
 	for _, c := range cases {

--- a/definition.go
+++ b/definition.go
@@ -61,7 +61,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	var Reliabilities Reliabilities
 	log.Printf("[debug] expr objective count = %d", len(d.exprObjectives))
 	for _, o := range d.exprObjectives {
-		rc, err := o.NewReliabilities(d.calculate, metrics, startAt, endAt)
+		rc, err := o.CalculateReliabilities(d.calculate, metrics, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	}
 	log.Printf("[debug] alert objective count = %d", len(d.alertObjectives))
 	for _, o := range d.alertObjectives {
-		rc, err := o.NewReliabilities(d.calculate, alerts, startAt, endAt)
+		rc, err := o.CalculateReliabilities(d.calculate, alerts, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}

--- a/definition.go
+++ b/definition.go
@@ -61,7 +61,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	var Reliabilities Reliabilities
 	log.Printf("[debug] expr objective count = %d", len(d.exprObjectives))
 	for _, o := range d.exprObjectives {
-		rc, err := o.CalculateReliabilities(d.calculate, metrics, startAt, endAt)
+		rc, err := o.EvaluateReliabilities(d.calculate, metrics, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	}
 	log.Printf("[debug] alert objective count = %d", len(d.alertObjectives))
 	for _, o := range d.alertObjectives {
-		rc, err := o.CalculateReliabilities(d.calculate, alerts, startAt, endAt)
+		rc, err := o.EvaluateReliabilities(d.calculate, alerts, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}

--- a/definition.go
+++ b/definition.go
@@ -105,7 +105,7 @@ func (d *Definition) AlertObjectives(monitors []*Monitor) []*Monitor {
 	for _, m := range monitors {
 		for _, obj := range d.alertObjectives {
 			if obj.MatchMonitor(m) {
-				matched[m.ID] = m
+				matched[m.ID()] = m
 			}
 		}
 	}

--- a/definition.go
+++ b/definition.go
@@ -58,33 +58,33 @@ func (d *Definition) CreateReports(ctx context.Context, metrics Metrics, alerts 
 	endAt = endAt.Add(+time.Nanosecond).Truncate(d.calculate).Add(-time.Nanosecond)
 	log.Printf("[debug] truncate report range = %s ~ %s", startAt, endAt)
 	log.Printf("[debug] timeFrame = %s, calcurateInterval = %s", d.timeFrame, d.calculate)
-	var reliabilityCollection ReliabilityCollection
+	var Reliabilities Reliabilities
 	log.Printf("[debug] expr objective count = %d", len(d.exprObjectives))
 	for _, o := range d.exprObjectives {
-		rc, err := o.NewReliabilityCollection(d.calculate, metrics, startAt, endAt)
+		rc, err := o.NewReliabilities(d.calculate, metrics, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}
-		reliabilityCollection, err = reliabilityCollection.Merge(rc)
+		Reliabilities, err = Reliabilities.Merge(rc)
 		if err != nil {
 			return nil, err
 		}
 	}
 	log.Printf("[debug] alert objective count = %d", len(d.alertObjectives))
 	for _, o := range d.alertObjectives {
-		rc, err := o.NewReliabilityCollection(d.calculate, alerts, startAt, endAt)
+		rc, err := o.NewReliabilities(d.calculate, alerts, startAt, endAt)
 		if err != nil {
 			return nil, err
 		}
-		reliabilityCollection, err = reliabilityCollection.Merge(rc)
+		Reliabilities, err = Reliabilities.Merge(rc)
 		if err != nil {
 			return nil, err
 		}
 	}
-	for _, r := range reliabilityCollection {
+	for _, r := range Reliabilities {
 		log.Printf("[debug] reliability[%s~%s] =  (%s, %s)", r.TimeFrameStartAt(), r.TimeFrameEndAt(), r.UpTime(), r.FailureTime())
 	}
-	reports := NewReports(d.id, d.destination, d.errorBudgetSize, d.timeFrame, reliabilityCollection)
+	reports := NewReports(d.id, d.destination, d.errorBudgetSize, d.timeFrame, Reliabilities)
 	sort.Slice(reports, func(i, j int) bool {
 		return reports[i].DataPoint.Before(reports[j].DataPoint)
 	})

--- a/definition_test.go
+++ b/definition_test.go
@@ -65,16 +65,20 @@ func TestDefinition(t *testing.T) {
 	defer restore()
 	alerts := shimesaba.Alerts{
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID: "hogera",
-			},
+			shimesaba.NewMonitor(
+				"hogera",
+				"hogera.example.com",
+				"external",
+			),
 			time.Date(2021, 10, 1, 0, 3, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, 10, 1, 0, 9, 0, 0, time.UTC)),
 		),
 		shimesaba.NewAlert(
-			&shimesaba.Monitor{
-				ID: "hogera",
-			},
+			shimesaba.NewMonitor(
+				"hogera",
+				"hogera.example.com",
+				"external",
+			),
 			time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC),
 			nil,
 		),

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -16,7 +16,7 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 	return &ExprObjective{expr: expr}
 }
 
-func (o *ExprObjective) CalculateReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
+func (o *ExprObjective) EvaluateReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/mashiike/evaluator"
-	"github.com/mashiike/shimesaba/internal/timeutils"
 )
 
 type ExprObjective struct {
@@ -18,14 +17,7 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 
 func (o *ExprObjective) EvaluateReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
-	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
-	iter.SetEnableOverWindow(true)
-	reliabilitySlice := make([]*Reliability, 0)
-	for iter.HasNext() {
-		cursorAt, _ := iter.Next()
-		reliabilitySlice = append(reliabilitySlice, NewReliability(cursorAt, timeFrame, isNoViolation))
-	}
-	return NewReliabilities(reliabilitySlice)
+	return isNoViolation.NewReliabilities(timeFrame, startAt, endAt)
 }
 
 func (o *ExprObjective) newIsNoViolation(metrics Metrics) IsNoViolationCollection {

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -16,7 +16,7 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 	return &ExprObjective{expr: expr}
 }
 
-func (o *ExprObjective) NewReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
+func (o *ExprObjective) CalculateReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)

--- a/expr_objective.go
+++ b/expr_objective.go
@@ -16,7 +16,7 @@ func NewExprObjective(expr evaluator.Comparator) *ExprObjective {
 	return &ExprObjective{expr: expr}
 }
 
-func (o *ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (ReliabilityCollection, error) {
+func (o *ExprObjective) NewReliabilities(timeFrame time.Duration, metrics Metrics, startAt, endAt time.Time) (Reliabilities, error) {
 	isNoViolation := o.newIsNoViolation(metrics)
 	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
 	iter.SetEnableOverWindow(true)
@@ -25,7 +25,7 @@ func (o *ExprObjective) NewReliabilityCollection(timeFrame time.Duration, metric
 		cursorAt, _ := iter.Next()
 		reliabilitySlice = append(reliabilitySlice, NewReliability(cursorAt, timeFrame, isNoViolation))
 	}
-	return NewReliabilityCollection(reliabilitySlice)
+	return NewReliabilities(reliabilitySlice)
 }
 
 func (o *ExprObjective) newIsNoViolation(metrics Metrics) map[time.Time]bool {

--- a/expr_objective_test.go
+++ b/expr_objective_test.go
@@ -85,7 +85,6 @@ func TestExprObjective(t *testing.T) {
 			require.NoError(t, err)
 			expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
-				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),
 			})
 			require.EqualValues(t, expected, actual)
 		})

--- a/expr_objective_test.go
+++ b/expr_objective_test.go
@@ -76,7 +76,7 @@ func TestExprObjective(t *testing.T) {
 			comparator, ok := e.AsComparator()
 			require.EqualValues(t, true, ok)
 			obj := shimesaba.NewExprObjective(comparator)
-			actual, err := obj.NewReliabilities(
+			actual, err := obj.CalculateReliabilities(
 				time.Minute,
 				metrics,
 				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC),

--- a/expr_objective_test.go
+++ b/expr_objective_test.go
@@ -76,7 +76,7 @@ func TestExprObjective(t *testing.T) {
 			comparator, ok := e.AsComparator()
 			require.EqualValues(t, true, ok)
 			obj := shimesaba.NewExprObjective(comparator)
-			actual, err := obj.CalculateReliabilities(
+			actual, err := obj.EvaluateReliabilities(
 				time.Minute,
 				metrics,
 				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC),

--- a/expr_objective_test.go
+++ b/expr_objective_test.go
@@ -76,14 +76,14 @@ func TestExprObjective(t *testing.T) {
 			comparator, ok := e.AsComparator()
 			require.EqualValues(t, true, ok)
 			obj := shimesaba.NewExprObjective(comparator)
-			actual, err := obj.NewReliabilityCollection(
+			actual, err := obj.NewReliabilities(
 				time.Minute,
 				metrics,
 				time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC),
 				time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
 			)
 			require.NoError(t, err)
-			expected, _ := shimesaba.NewReliabilityCollection([]*shimesaba.Reliability{
+			expected, _ := shimesaba.NewReliabilities([]*shimesaba.Reliability{
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 1, 0, 0, time.UTC), time.Minute, c.expected),
 				shimesaba.NewReliability(time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC), time.Minute, c.expected),
 			})

--- a/mackerel.go
+++ b/mackerel.go
@@ -362,7 +362,7 @@ func (repo *Repository) getMonitor(id string) (*Monitor, error) {
 		return nil, err
 	}
 	log.Printf("[debug] catch monitor[%s] = %#v", id, monitor)
-	repo.monitorByID[id] = newMonitor(monitor)
+	repo.monitorByID[id] = convertMonitor(monitor)
 	return repo.monitorByID[id], nil
 }
 
@@ -376,19 +376,19 @@ func (repo *Repository) FindMonitors() ([]*Monitor, error) {
 	}
 	ret := make([]*Monitor, 0, len(monitors))
 	for _, m := range monitors {
-		monitor := newMonitor(m)
-		repo.monitorByID[monitor.ID] = monitor
+		monitor := convertMonitor(m)
+		repo.monitorByID[monitor.ID()] = monitor
 		ret = append(ret, monitor)
 	}
 	return ret, nil
 }
 
-func newMonitor(monitor mackerel.Monitor) *Monitor {
-	return &Monitor{
-		ID:   monitor.MonitorID(),
-		Name: monitor.MonitorName(),
-		Type: monitor.MonitorType(),
-	}
+func convertMonitor(monitor mackerel.Monitor) *Monitor {
+	return NewMonitor(
+		monitor.MonitorID(),
+		monitor.MonitorName(),
+		monitor.MonitorType(),
+	)
 }
 
 func (repo *Repository) WithDryRun() *Repository {

--- a/mackerel.go
+++ b/mackerel.go
@@ -393,6 +393,7 @@ func (repo *Repository) convertMonitor(monitor mackerel.Monitor) *Monitor {
 	switch monitor := monitor.(type) {
 	case *mackerel.MonitorHostMetric:
 		m = m.WithEvaluator(func(hostID string, timeFrame time.Duration, startAt, endAt time.Time) (Reliabilities, bool) {
+			log.Printf("[debug] try evaluate host metric, host_id=`%s`, monitor=`%s` time=%s~%s", hostID, monitor.Name, startAt, endAt)
 			metrics, err := repo.client.FetchHostMetricValues(hostID, monitor.Metric, startAt.Unix(), endAt.Unix())
 			if err != nil {
 				log.Printf("[debug] FetchHostMetricValues failed: %s", err)
@@ -411,12 +412,14 @@ func (repo *Repository) convertMonitor(monitor mackerel.Monitor) *Monitor {
 					if monitor.Warning != nil {
 						if value > *monitor.Warning {
 							isNoViolation[cursorAt] = false
+							log.Printf("[debug] monitor `%s`, SLO Violation, host_id=`%s`, time=`%s`,  value[%f] > warning[%f]", monitor.Name, hostID, cursorAt, value, *monitor.Warning)
 							continue
 						}
 					}
 					if monitor.Critical != nil {
 						if value > *monitor.Critical {
 							isNoViolation[cursorAt] = false
+							log.Printf("[debug] monitor `%s`, SLO Violation, hostId=`%s`, time=`%s`,  value[%f] > critical[%f]", monitor.Name, hostID, cursorAt, value, *monitor.Critical)
 							continue
 						}
 					}
@@ -424,12 +427,14 @@ func (repo *Repository) convertMonitor(monitor mackerel.Monitor) *Monitor {
 					if monitor.Warning != nil {
 						if value < *monitor.Warning {
 							isNoViolation[cursorAt] = false
+							log.Printf("[debug] monitor `%s`, SLO Violation, hostId=`%s`, time=`%s`,  value[%f] < warning[%f]", monitor.Name, hostID, cursorAt, value, *monitor.Warning)
 							continue
 						}
 					}
 					if monitor.Critical != nil {
 						if value < *monitor.Critical {
 							isNoViolation[cursorAt] = false
+							log.Printf("[debug] monitor `%s`, SLO Violation, hostId=`%s`, time=`%s`,  value[%f] < critical[%f]", monitor.Name, hostID, cursorAt, value, *monitor.Warning)
 							continue
 						}
 					}

--- a/mackerel.go
+++ b/mackerel.go
@@ -18,6 +18,7 @@ import (
 
 // MackerelClient is an abstraction interface for mackerel-client-go.Client
 type MackerelClient interface {
+	GetOrg() (*mackerel.Org, error)
 	FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error)
 	FetchHostMetricValues(hostID string, metricName string, from int64, to int64) ([]mackerel.MetricValue, error)
 	FetchServiceMetricValues(serviceName string, metricName string, from int64, to int64) ([]mackerel.MetricValue, error)
@@ -48,6 +49,14 @@ func NewRepository(client MackerelClient) *Repository {
 		client:      client,
 		monitorByID: make(map[string]*Monitor),
 	}
+}
+
+func (repo *Repository) GetOrgName(ctx context.Context) (string, error) {
+	org, err := repo.client.GetOrg()
+	if err != nil {
+		return "", err
+	}
+	return org.Name, nil
 }
 
 const (

--- a/mackerel.go
+++ b/mackerel.go
@@ -343,7 +343,7 @@ func (repo *Repository) convertAlerts(resp *mackerel.AlertsResp, endAt time.Time
 			openedAt,
 			closedAt,
 		)
-		a = a.WithHostID(alert.HostID)
+		a = a.WithHostID(alert.HostID).WithReason(alert.Reason)
 		log.Printf("[debug] %s", a)
 		alerts = append(alerts, a)
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -1,13 +1,35 @@
 package shimesaba
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Monitor struct {
-	ID   string
-	Name string
-	Type string
+	id          string
+	name        string
+	monitorType string
+}
+
+func NewMonitor(id, name, monitorType string) *Monitor {
+	return &Monitor{
+		id:          id,
+		name:        name,
+		monitorType: monitorType,
+	}
+}
+
+func (m *Monitor) ID() string {
+	return m.id
+}
+
+func (m *Monitor) Name() string {
+	return m.name
+}
+
+func (m *Monitor) Type() string {
+	return m.monitorType
 }
 
 func (m *Monitor) String() string {
-	return fmt.Sprintf("[%s]%s", m.Type, m.Name)
+	return fmt.Sprintf("[%s]%s", m.monitorType, m.name)
 }

--- a/monitor.go
+++ b/monitor.go
@@ -2,12 +2,14 @@ package shimesaba
 
 import (
 	"fmt"
+	"time"
 )
 
 type Monitor struct {
 	id          string
 	name        string
 	monitorType string
+	evaluator   func(hostID string, timeFrame time.Duration, startAt, endAt time.Time) (Reliabilities, bool)
 }
 
 func NewMonitor(id, name, monitorType string) *Monitor {
@@ -15,6 +17,15 @@ func NewMonitor(id, name, monitorType string) *Monitor {
 		id:          id,
 		name:        name,
 		monitorType: monitorType,
+	}
+}
+
+func (m *Monitor) WithEvaluator(evaluator func(hostID string, timeFrame time.Duration, startAt, endAt time.Time) (Reliabilities, bool)) *Monitor {
+	return &Monitor{
+		id:          m.id,
+		name:        m.name,
+		monitorType: m.monitorType,
+		evaluator:   evaluator,
 	}
 }
 
@@ -32,4 +43,11 @@ func (m *Monitor) Type() string {
 
 func (m *Monitor) String() string {
 	return fmt.Sprintf("[%s]%s", m.monitorType, m.name)
+}
+
+func (m *Monitor) EvaluateReliabilities(hostID string, timeFrame time.Duration, startAt, endAt time.Time) (Reliabilities, bool) {
+	if m.evaluator == nil {
+		return nil, false
+	}
+	return m.evaluator(hostID, timeFrame, startAt, endAt)
 }

--- a/reliability.go
+++ b/reliability.go
@@ -27,6 +27,17 @@ func (c IsNoViolationCollection) IsUp(t time.Time) bool {
 	return true
 }
 
+func (c IsNoViolationCollection) NewReliabilities(timeFrame time.Duration, startAt, endAt time.Time) (Reliabilities, error) {
+	startAt = startAt.Truncate(timeFrame)
+	iter := timeutils.NewIterator(startAt, endAt, timeFrame)
+	reliabilitySlice := make([]*Reliability, 0)
+	for iter.HasNext() {
+		cursorAt, _ := iter.Next()
+		reliabilitySlice = append(reliabilitySlice, NewReliability(cursorAt, timeFrame, c))
+	}
+	return NewReliabilities(reliabilitySlice)
+}
+
 func NewReliability(cursorAt time.Time, timeFrame time.Duration, isNoViolation IsNoViolationCollection) *Reliability {
 	cursorAt = cursorAt.Truncate(timeFrame).Add(timeFrame).UTC()
 	r := &Reliability{

--- a/reliability.go
+++ b/reliability.go
@@ -117,11 +117,11 @@ func (r *Reliability) Merge(other *Reliability) (*Reliability, error) {
 	return cloned, nil
 }
 
-// ReliabilityCollection is sortable
-type ReliabilityCollection []*Reliability
+// Reliabilities is sortable
+type Reliabilities []*Reliability
 
-func NewReliabilityCollection(s []*Reliability) (ReliabilityCollection, error) {
-	c := ReliabilityCollection(s)
+func NewReliabilities(s []*Reliability) (Reliabilities, error) {
+	c := Reliabilities(s)
 	sort.Sort(c)
 	if c.Len() == 0 {
 		return c, nil
@@ -140,12 +140,12 @@ func NewReliabilityCollection(s []*Reliability) (ReliabilityCollection, error) {
 	return c, nil
 }
 
-func (c ReliabilityCollection) Len() int           { return len(c) }
-func (c ReliabilityCollection) Less(i, j int) bool { return c[i].CursorAt().After(c[j].CursorAt()) }
-func (c ReliabilityCollection) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c Reliabilities) Len() int           { return len(c) }
+func (c Reliabilities) Less(i, j int) bool { return c[i].CursorAt().After(c[j].CursorAt()) }
+func (c Reliabilities) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
-func (c ReliabilityCollection) Clone() ReliabilityCollection {
-	cloned := make(ReliabilityCollection, 0, len(c))
+func (c Reliabilities) Clone() Reliabilities {
+	cloned := make(Reliabilities, 0, len(c))
 	for _, r := range c {
 		cloned = append(cloned, r.Clone())
 	}
@@ -153,7 +153,7 @@ func (c ReliabilityCollection) Clone() ReliabilityCollection {
 	return cloned
 }
 
-func (c ReliabilityCollection) CalcTime(cursor, n int) (upTime, failureTime, deltaFailureTime time.Duration) {
+func (c Reliabilities) CalcTime(cursor, n int) (upTime, failureTime, deltaFailureTime time.Duration) {
 	deltaFailureTime = c[cursor].FailureTime()
 	i := cursor
 	for ; i < cursor+n && i < c.Len(); i++ {
@@ -171,7 +171,7 @@ func (c ReliabilityCollection) CalcTime(cursor, n int) (upTime, failureTime, del
 }
 
 //TimeFrame is the size of the tumbling window
-func (c ReliabilityCollection) TimeFrame() time.Duration {
+func (c Reliabilities) TimeFrame() time.Duration {
 	if c.Len() == 0 {
 		return 0
 	}
@@ -179,7 +179,7 @@ func (c ReliabilityCollection) TimeFrame() time.Duration {
 }
 
 //CursorAt is a representative value of the time shown by the tumbling window
-func (c ReliabilityCollection) CursorAt(i int) time.Time {
+func (c Reliabilities) CursorAt(i int) time.Time {
 	if c.Len() == 0 {
 		return time.Unix(0, 0)
 	}
@@ -187,11 +187,11 @@ func (c ReliabilityCollection) CursorAt(i int) time.Time {
 }
 
 //Merge two collection
-func (c ReliabilityCollection) Merge(other ReliabilityCollection) (ReliabilityCollection, error) {
+func (c Reliabilities) Merge(other Reliabilities) (Reliabilities, error) {
 	return c.MergeInRange(other, time.Unix(0, 0).UTC(), time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC))
 }
 
-func (c ReliabilityCollection) MergeInRange(other ReliabilityCollection, startAt, endAt time.Time) (ReliabilityCollection, error) {
+func (c Reliabilities) MergeInRange(other Reliabilities, startAt, endAt time.Time) (Reliabilities, error) {
 	if len(other) == 0 {
 		return c.Clone(), nil
 	}
@@ -230,5 +230,5 @@ func (c ReliabilityCollection) MergeInRange(other ReliabilityCollection, startAt
 	for _, r := range reliabilityByCursorAt {
 		merged = append(merged, r)
 	}
-	return NewReliabilityCollection(merged)
+	return NewReliabilities(merged)
 }

--- a/reliability.go
+++ b/reliability.go
@@ -188,6 +188,10 @@ func (c ReliabilityCollection) CursorAt(i int) time.Time {
 
 //Merge two collection
 func (c ReliabilityCollection) Merge(other ReliabilityCollection) (ReliabilityCollection, error) {
+	return c.MergeInRange(other, time.Unix(0, 0).UTC(), time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC))
+}
+
+func (c ReliabilityCollection) MergeInRange(other ReliabilityCollection, startAt, endAt time.Time) (ReliabilityCollection, error) {
 	if len(other) == 0 {
 		return c.Clone(), nil
 	}
@@ -196,9 +200,21 @@ func (c ReliabilityCollection) Merge(other ReliabilityCollection) (ReliabilityCo
 	}
 	reliabilityByCursorAt := make(map[time.Time]*Reliability, len(c))
 	for _, r := range c {
+		if r.TimeFrameStartAt().Before(startAt) {
+			continue
+		}
+		if r.TimeFrameStartAt().After(endAt) {
+			continue
+		}
 		reliabilityByCursorAt[r.CursorAt()] = r.Clone()
 	}
 	for _, r := range other {
+		if r.TimeFrameStartAt().Before(startAt) {
+			continue
+		}
+		if r.TimeFrameStartAt().After(endAt) {
+			continue
+		}
 		cursorAt := r.CursorAt()
 		if base, ok := reliabilityByCursorAt[cursorAt]; ok {
 			var err error

--- a/reliability_test.go
+++ b/reliability_test.go
@@ -71,7 +71,7 @@ func TestReliabilityMerge(t *testing.T) {
 	require.True(t, actual.UpTime()+actual.FailureTime() == actual.TimeFrame(), "upTime + failureTime = timeFrame")
 }
 
-func TestReliabilityCollection(t *testing.T) {
+func TestReliabilities(t *testing.T) {
 	allTimeIsNoViolation := map[time.Time]bool{
 
 		time.Date(2022, 1, 6, 8, 28, 0, 0, time.UTC): true,
@@ -91,7 +91,7 @@ func TestReliabilityCollection(t *testing.T) {
 		time.Date(2022, 1, 6, 10, 40, 0, 0, time.UTC): false,
 	}
 	tumblingWindowTimeFrame := time.Hour
-	c, err := shimesaba.NewReliabilityCollection(
+	c, err := shimesaba.NewReliabilities(
 		[]*shimesaba.Reliability{
 			shimesaba.NewReliability(
 				time.Date(2022, 1, 6, 9, 0, 0, 0, time.UTC),
@@ -126,7 +126,7 @@ func TestReliabilityCollection(t *testing.T) {
 	require.EqualValues(t, 2*time.Minute, deltaFailureTime, "2nd deltaFailureTime")
 }
 
-func TestReliabilityCollectionMerge(t *testing.T) {
+func TestReliabilitiesMerge(t *testing.T) {
 
 	tumblingWindowTimeFrame := time.Hour
 	baseAllTimeIsNoViolation := map[time.Time]bool{
@@ -147,7 +147,7 @@ func TestReliabilityCollectionMerge(t *testing.T) {
 		time.Date(2022, 1, 6, 10, 39, 0, 0, time.UTC): false,
 		time.Date(2022, 1, 6, 10, 40, 0, 0, time.UTC): false,
 	}
-	base, err := shimesaba.NewReliabilityCollection(
+	base, err := shimesaba.NewReliabilities(
 		[]*shimesaba.Reliability{
 			shimesaba.NewReliability(
 				time.Date(2022, 1, 6, 9, 0, 0, 0, time.UTC),
@@ -185,7 +185,7 @@ func TestReliabilityCollectionMerge(t *testing.T) {
 		time.Date(2022, 1, 6, 10, 2, 0, 0, time.UTC): false,
 		time.Date(2022, 1, 6, 10, 3, 0, 0, time.UTC): false,
 	}
-	other, err := shimesaba.NewReliabilityCollection(
+	other, err := shimesaba.NewReliabilities(
 		[]*shimesaba.Reliability{
 			shimesaba.NewReliability(
 				time.Date(2022, 1, 6, 7, 0, 0, 0, time.UTC),

--- a/report.go
+++ b/report.go
@@ -32,7 +32,7 @@ func NewReport(definitionID string, destination *Destination, cursorAt time.Time
 	return report
 }
 
-func NewReports(definitionID string, destination *Destination, errorBudgetSize float64, timeFrame time.Duration, reliability ReliabilityCollection) []*Report {
+func NewReports(definitionID string, destination *Destination, errorBudgetSize float64, timeFrame time.Duration, reliability Reliabilities) []*Report {
 	if reliability.Len() == 0 {
 		return make([]*Report, 0)
 	}

--- a/report_test.go
+++ b/report_test.go
@@ -86,7 +86,7 @@ func TestNewReports(t *testing.T) {
 		time.Date(2022, 1, 6, 10, 40, 0, 0, time.UTC): false,
 	}
 	tumblingWindowTimeFrame := time.Hour
-	c, _ := shimesaba.NewReliabilityCollection(
+	c, _ := shimesaba.NewReliabilities(
 		[]*shimesaba.Reliability{
 			shimesaba.NewReliability(
 				time.Date(2022, 1, 6, 9, 0, 0, 0, time.UTC),

--- a/testdata/v0.7.0.yaml
+++ b/testdata/v0.7.0.yaml
@@ -1,0 +1,21 @@
+required_version: ">=0.7.0"
+
+service_name:  prod
+time_frame: 28d
+calculate_interval: 1h
+error_budget_size: 40m
+
+definitions:
+  - id: external_api_availability
+    metric_prefix: external
+    metric_suffix: availability
+    objectives:
+      - monitor_name_suffix: api.example.com
+        monitor_type: external
+  - id: internal_api_availability
+    metric_prefix: internal
+    metric_suffix: availability
+    objectives:
+      - monitor_name_suffix: api.example.com
+        monitor_type: external
+


### PR DESCRIPTION
In v0.7.0, we will make some major changes.

There are some deprecated features that will be removed in v0.8.0.
- dashboard subcommand and subcommand calls
- SLO definition using expr and metric

Add the following features
- When SHIMESABA_ENABLE_REASSESSMENT is specified, enable experimental high precision function for host metric monitoring and service metric monitoring.
- Provides Manual correction feature. The SLO violation time can be specified in the alert close reason in a certain format.

Translated with www.DeepL.com/Translator (free version)