### PR TITLE
In v1.2.0 and later, the default for UpTime and FailureTime is Disabled.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -31,8 +31,6 @@ func TestAppWithMock(t *testing.T) {
 						"shimesaba.error_budget_consumption_percentage.alerts": backfill,
 						"shimesaba.error_budget_percentage.alerts":             backfill,
 						"shimesaba.error_budget_remaining_percentage.alerts":   backfill,
-						"shimesaba.failure_time.alerts":                        backfill,
-						"shimesaba.uptime.alerts":                              backfill,
 					},
 				},
 				{
@@ -40,6 +38,18 @@ func TestAppWithMock(t *testing.T) {
 					expected: map[string]int{
 						"app_test.eb.availability":  backfill,
 						"app_test.ebr.availability": backfill,
+					},
+				},
+				{
+					configFile: "testdata/app_uptime_and_failuretime.yaml",
+					expected: map[string]int{
+						"shimesaba.error_budget.alerts":                        backfill,
+						"shimesaba.error_budget_consumption.alerts":            backfill,
+						"shimesaba.error_budget_consumption_percentage.alerts": backfill,
+						"shimesaba.error_budget_percentage.alerts":             backfill,
+						"shimesaba.error_budget_remaining_percentage.alerts":   backfill,
+						"shimesaba.failure_time.alerts":                        backfill,
+						"shimesaba.uptime.alerts":                              backfill,
 					},
 				},
 			}

--- a/destination_metric_type.go
+++ b/destination_metric_type.go
@@ -1,7 +1,5 @@
 package shimesaba
 
-import "log"
-
 type DestinationMetricType int
 
 //go:generate go install github.com/dmarkham/enumer
@@ -28,8 +26,7 @@ func (t DestinationMetricType) DefaultTypeName() string {
 func (t DestinationMetricType) DefaultEnabled() bool {
 	switch t {
 	case UpTime, FailureTime:
-		log.Printf("[warn] In the near future the default value of `enabled` for `%s` metrics will be false, please specify explicitly in config", t.ID())
-		return true
+		return false
 	default:
 		return true
 	}

--- a/testdata/app_uptime_and_failuretime.yaml
+++ b/testdata/app_uptime_and_failuretime.yaml
@@ -1,0 +1,20 @@
+
+required_version: ">=1.2.0"
+
+destination:
+  metrics:
+    uptime:
+      enabled: true
+    failure_time:
+      enabled: true
+
+slo:
+  - id: alerts
+    destination:
+      service_name:  shimesaba
+    rolling_period: 5m
+    calculate_interval: 1m
+    error_budget_size: 0.1
+    alert_based_sli:
+      - monitor_id: "dummyMonitorID"
+      - monitor_name_prefix: "Dummy"


### PR DESCRIPTION
`[warn] In the near future the default value of `enabled` for `%s` metrics will be false, please specify explicitly in config`

In v1.2.0 and later, the default for UpTime and FailureTime is Disabled.
If you want these two metrics to be output, explicitly enable them in config.