### PR TITLE
Ability to make graph annotations virtual alerts

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -33,6 +33,16 @@ func NewAlert(monitor *Monitor, openedAt time.Time, closedAt *time.Time) *Alert 
 		ClosedAt: closedAt,
 	}
 }
+
+func NewVirtualAlert(description string, openedAt time.Time, closedAt time.Time) *Alert {
+	closedAt = closedAt.Truncate(time.Minute).UTC()
+	return &Alert{
+		OpenedAt: openedAt.Truncate(time.Minute).UTC(),
+		ClosedAt: &closedAt,
+		Reason:   description,
+	}
+}
+
 func (alert *Alert) WithHostID(hostID string) *Alert {
 	return &Alert{
 		Monitor:  alert.Monitor,
@@ -60,6 +70,10 @@ func (alert *Alert) String() string {
 		alert.OpenedAt,
 		alert.ClosedAt,
 	)
+}
+
+func (alert *Alert) IsVirtual() bool {
+	return alert.Monitor == nil
 }
 
 func (alert *Alert) endAt() time.Time {

--- a/alert_based_sli.go
+++ b/alert_based_sli.go
@@ -45,6 +45,9 @@ func (o AlertBasedSLI) EvaluateReliabilities(timeFrame time.Duration, alerts Ale
 }
 
 func (o AlertBasedSLI) matchAlert(alert *Alert) bool {
+	if alert.IsVirtual() {
+		return true
+	}
 	log.Printf("[debug] try match %s vs %v", alert, o.cfg)
 	if o.MatchMonitor(alert.Monitor) {
 		log.Printf("[debug] match %s", alert)

--- a/alert_test.go
+++ b/alert_test.go
@@ -41,6 +41,11 @@ func TestAlerts(t *testing.T) {
 			time.Date(2021, time.October, 1, 0, 3, 0, 0, time.UTC),
 			ptrTime(time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC)),
 		),
+		shimesaba.NewVirtualAlert(
+			"slo:hoge",
+			time.Date(2021, time.October, 1, 0, 2, 0, 0, time.UTC),
+			time.Date(2021, time.October, 1, 0, 4, 0, 0, time.UTC),
+		),
 	}
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC), alerts.StartAt())
 	require.EqualValues(t, time.Date(2021, time.October, 1, 0, 5, 0, 0, time.UTC), alerts.EndAt())

--- a/app_test.go
+++ b/app_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Songmu/flextime"
-	mackerel "github.com/mackerelio/mackerel-client-go"
 	"github.com/mashiike/shimesaba"
 	"github.com/mashiike/shimesaba/internal/logger"
 	"github.com/stretchr/testify/require"
@@ -84,88 +83,4 @@ func TestAppWithMock(t *testing.T) {
 			}
 		})
 	}
-}
-
-type mockMackerelClient struct {
-	shimesaba.MackerelClient
-	posted []*mackerel.MetricValue
-	t      *testing.T
-}
-
-func newMockMackerelClient(t *testing.T) *mockMackerelClient {
-	t.Helper()
-	return &mockMackerelClient{
-		t: t,
-	}
-}
-
-func (m *mockMackerelClient) GetOrg() (*mackerel.Org, error) {
-	return &mackerel.Org{
-		Name: "dummy",
-	}, nil
-}
-
-func (m *mockMackerelClient) FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error) {
-	require.EqualValues(
-		m.t,
-		&mackerel.FindHostsParam{
-			Service: "shimesaba",
-			Name:    "dummy-alb",
-		},
-		param,
-	)
-	return []*mackerel.Host{
-		{
-			ID: "dummyHostID",
-		},
-	}, nil
-}
-
-func (m *mockMackerelClient) PostServiceMetricValues(serviceName string, metricValues []*mackerel.MetricValue) error {
-	require.Equal(m.t, "shimesaba", serviceName)
-	m.posted = append(m.posted, metricValues...)
-	return nil
-}
-
-func (m *mockMackerelClient) FindWithClosedAlerts() (*mackerel.AlertsResp, error) {
-	return &mackerel.AlertsResp{
-		Alerts: []*mackerel.Alert{
-			{
-				ID:        "dummyID20211001-001900",
-				Status:    "WARNING",
-				MonitorID: "dummyMonitorID",
-				OpenedAt:  time.Date(2021, 10, 1, 0, 19, 0, 0, time.UTC).Unix(),
-				Value:     0.01,
-				Type:      "service",
-			},
-		},
-		NextID: "dummyNextID",
-	}, nil
-}
-
-func (m *mockMackerelClient) FindWithClosedAlertsByNextID(nextID string) (*mackerel.AlertsResp, error) {
-	require.Equal(m.t, "dummyNextID", nextID)
-	return &mackerel.AlertsResp{
-		Alerts: []*mackerel.Alert{
-			{
-				ID:        "dummyID20211001-001000",
-				Status:    "OK",
-				MonitorID: "dummyMonitorID",
-				OpenedAt:  time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
-				ClosedAt:  time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
-				Value:     0.01,
-				Type:      "service",
-			},
-		},
-		NextID: "",
-	}, nil
-}
-
-func (m *mockMackerelClient) GetMonitor(monitorID string) (mackerel.Monitor, error) {
-	require.Equal(m.t, "dummyMonitorID", monitorID)
-	return &mackerel.MonitorServiceMetric{
-		ID:   monitorID,
-		Name: "Dummy Service Metric Monitor",
-		Type: "service",
-	}, nil
 }

--- a/definition.go
+++ b/definition.go
@@ -41,6 +41,7 @@ func (d *Definition) ID() string {
 
 type DataProvider interface {
 	FetchAlerts(ctx context.Context, startAt time.Time, endAt time.Time) (Alerts, error)
+	FetchVirtualAlerts(ctx context.Context, serviceName string, sloID string, startAt time.Time, endAt time.Time) (Alerts, error)
 }
 
 // CreateReports returns Report with Metrics
@@ -50,6 +51,11 @@ func (d *Definition) CreateReports(ctx context.Context, provider DataProvider, n
 	if err != nil {
 		return nil, err
 	}
+	valerts, err := provider.FetchVirtualAlerts(ctx, d.destination.ServiceName, d.id, startAt, now)
+	if err != nil {
+		return nil, err
+	}
+	alerts = append(alerts, valerts...)
 	return d.CreateReportsWithAlertsAndPeriod(ctx, alerts, d.StartAt(now, backfill), now)
 }
 

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -1,0 +1,65 @@
+package shimesaba_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mashiike/shimesaba"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryFetchVirtualAlerts(t *testing.T) {
+	client := newMockMackerelClient(t)
+	repo := shimesaba.NewRepository(client)
+
+	cases := []struct {
+		name        string
+		serviceName string
+		sloID       string
+		startAt     time.Time
+		endAt       time.Time
+		expected    shimesaba.Alerts
+	}{
+		{
+			name:        "SLO:*",
+			serviceName: "shimesaba",
+			sloID:       "hoge",
+			startAt:     time.Date(2021, 10, 1, 0, 5, 0, 0, time.UTC),
+			endAt:       time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC),
+			expected: shimesaba.Alerts{
+				{
+					Reason:   "SLO:*",
+					OpenedAt: time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC),
+					ClosedAt: ptrTime(time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC)),
+				},
+			},
+		},
+		{
+			name:        "SLO:availability,quarity ",
+			serviceName: "shimesaba",
+			sloID:       "availability",
+			startAt:     time.Date(2021, 10, 1, 0, 5, 0, 0, time.UTC),
+			endAt:       time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC),
+			expected: shimesaba.Alerts{
+				{
+					Reason:   "SLO:*",
+					OpenedAt: time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC),
+					ClosedAt: ptrTime(time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC)),
+				},
+				{
+					Reason:   "ALB Failures SLO:availability,quarity affected.",
+					OpenedAt: time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC),
+					ClosedAt: ptrTime(time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			vAlerts, err := repo.FetchVirtualAlerts(context.Background(), c.serviceName, c.sloID, c.startAt, c.endAt)
+			require.NoError(t, err)
+			require.EqualValues(t, c.expected, vAlerts)
+		})
+	}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,0 +1,124 @@
+package shimesaba_test
+
+import (
+	"testing"
+	"time"
+
+	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mashiike/shimesaba"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMackerelClient struct {
+	shimesaba.MackerelClient
+	posted []*mackerel.MetricValue
+	t      *testing.T
+}
+
+func newMockMackerelClient(t *testing.T) *mockMackerelClient {
+	t.Helper()
+	return &mockMackerelClient{
+		t: t,
+	}
+}
+
+func (m *mockMackerelClient) GetOrg() (*mackerel.Org, error) {
+	return &mackerel.Org{
+		Name: "dummy",
+	}, nil
+}
+
+func (m *mockMackerelClient) FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error) {
+	require.EqualValues(
+		m.t,
+		&mackerel.FindHostsParam{
+			Service: "shimesaba",
+			Name:    "dummy-alb",
+		},
+		param,
+	)
+	return []*mackerel.Host{
+		{
+			ID: "dummyHostID",
+		},
+	}, nil
+}
+
+func (m *mockMackerelClient) PostServiceMetricValues(serviceName string, metricValues []*mackerel.MetricValue) error {
+	require.Equal(m.t, "shimesaba", serviceName)
+	m.posted = append(m.posted, metricValues...)
+	return nil
+}
+
+func (m *mockMackerelClient) FindWithClosedAlerts() (*mackerel.AlertsResp, error) {
+	return &mackerel.AlertsResp{
+		Alerts: []*mackerel.Alert{
+			{
+				ID:        "dummyID20211001-001900",
+				Status:    "WARNING",
+				MonitorID: "dummyMonitorID",
+				OpenedAt:  time.Date(2021, 10, 1, 0, 19, 0, 0, time.UTC).Unix(),
+				Value:     0.01,
+				Type:      "service",
+			},
+		},
+		NextID: "dummyNextID",
+	}, nil
+}
+
+func (m *mockMackerelClient) FindWithClosedAlertsByNextID(nextID string) (*mackerel.AlertsResp, error) {
+	require.Equal(m.t, "dummyNextID", nextID)
+	return &mackerel.AlertsResp{
+		Alerts: []*mackerel.Alert{
+			{
+				ID:        "dummyID20211001-001000",
+				Status:    "OK",
+				MonitorID: "dummyMonitorID",
+				OpenedAt:  time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
+				ClosedAt:  time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
+				Value:     0.01,
+				Type:      "service",
+			},
+		},
+		NextID: "",
+	}, nil
+}
+
+func (m *mockMackerelClient) GetMonitor(monitorID string) (mackerel.Monitor, error) {
+	require.Equal(m.t, "dummyMonitorID", monitorID)
+	return &mackerel.MonitorServiceMetric{
+		ID:   monitorID,
+		Name: "Dummy Service Metric Monitor",
+		Type: "service",
+	}, nil
+}
+
+var graphAnnotations = []mackerel.GraphAnnotation{
+	{
+		ID:          "xxxxxxxxxxx",
+		Title:       "hogehogehoge",
+		Description: "fugafugafuga",
+		From:        time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
+		To:          time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
+	},
+	{
+		ID:          "yyyyyyyyyyy",
+		Title:       "hogehogehoge",
+		Description: "SLO:*",
+		From:        time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
+		To:          time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
+	},
+	{
+		ID:          "zzzzzzzzzzz",
+		Title:       "hogehogehoge",
+		Description: "ALB Failures SLO:availability,quarity affected.",
+		From:        time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC).Unix(),
+		To:          time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC).Unix(),
+	},
+}
+
+func (m *mockMackerelClient) FindGraphAnnotations(service string, from int64, to int64) ([]mackerel.GraphAnnotation, error) {
+	require.Equal(m.t, "shimesaba", service)
+
+	return graphAnnotations, nil
+}


### PR DESCRIPTION
If additional monitoring rules are added after a failure, the
The error budget cannot be reduced because there is no alert for the newly added monitoring rule.

Therefore, we will implement a function that uses Graph Annotation to treat a specific format in the Description as a virtual alert.

This functionality will shave the error budget as a valid alert for all SLOs if `SLO:*` is described in the Graph Annotation

If the graph annotation is separated by commas, such as `SLO:slo_id1,slo_id2,slo_id3`, only the error budget for the SLO corresponding to the description will be shaved.
Caution : This description starts with `SLO:` and is valid until the next space.
If you write `SLO:slo_id1, slo_id2`, it is valid only for slo_id1.
