### PR TITLE
Parallelize the evaluate reliabilities of the alert

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -64,9 +64,12 @@ func (alert *Alert) WithReason(reason string) *Alert {
 }
 
 func (alert *Alert) String() string {
-	return fmt.Sprintf("alert[%s:%s] %s ~ %s",
-		alert.Monitor.ID(),
-		alert.Monitor.Name(),
+	monitor := "???"
+	if alert.Monitor != nil {
+		monitor = alert.Monitor.ID() + ":" + alert.Monitor.Name()
+	}
+	return fmt.Sprintf("alert[%s] %s ~ %s",
+		monitor,
 		alert.OpenedAt,
 		alert.ClosedAt,
 	)

--- a/alert_based_sli.go
+++ b/alert_based_sli.go
@@ -1,11 +1,14 @@
 package shimesaba
 
 import (
+	"context"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mashiike/shimesaba/internal/timeutils"
+	"golang.org/x/sync/errgroup"
 )
 
 type AlertBasedSLI struct {
@@ -28,19 +31,93 @@ func (o AlertBasedSLI) EvaluateReliabilities(timeFrame time.Duration, alerts Ale
 	if err != nil {
 		return nil, err
 	}
+
+	workerNum := 10
+	inputQueue := make(chan *Alert, len(alerts))
+	outputQueue := make(chan Reliabilities, workerNum*2)
+	quit := make(chan struct{})
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, egCtx := errgroup.WithContext(cancelCtx)
+	for i := 0; i < workerNum; i++ {
+		//input workers
+		workerID := i
+		eg.Go(func() error {
+			log.Printf("[debug] start EvaluateReliabilities input worker_id=%d", workerID)
+			for {
+				select {
+				case <-egCtx.Done():
+					log.Printf("[debug] end EvaluateReliabilities input worker_id=%d: %v", workerID, egCtx.Err())
+					return egCtx.Err()
+				case <-quit:
+					log.Printf("[debug] end EvaluateReliabilities input worker_id=%d: quit", workerID)
+					return nil
+				case alert, ok := <-inputQueue:
+					if !ok {
+						log.Printf("[debug] end EvaluateReliabilities input worker_id=%d: success", workerID)
+						return nil
+					}
+					log.Printf("[debug] worker_id=%d EvaluateReliabilities %s", workerID, alert.String())
+					tmp, err := alert.EvaluateReliabilities(timeFrame, o.cfg.TryReassessment)
+					if err != nil {
+						log.Printf("[debug] end EvaluateReliabilities input worker_id=%d: EvaluateReliabilities err: %v", workerID, err)
+						return err
+					}
+					outputQueue <- tmp
+				}
+			}
+		})
+	}
+	var outputErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		// output worker
+		log.Printf("[debug] start EvaluateReliabilities output worker")
+		defer wg.Done()
+		log.Printf("[debug] end EvaluateReliabilities output worker")
+		for {
+			select {
+			case <-cancelCtx.Done():
+				log.Printf("[debug] end EvaluateReliabilities output worker: %v", cancelCtx.Err())
+				return
+			case <-quit:
+				log.Printf("[debug] end EvaluateReliabilities output worker: quit")
+				return
+			case tmp, ok := <-outputQueue:
+				if !ok {
+					// Completed evaluation of all alerts
+					log.Printf("[debug] end EvaluateReliabilities output worker: success")
+					return
+				}
+				reliabilities, outputErr = reliabilities.MergeInRange(tmp, startAt, endAt)
+				if outputErr != nil {
+					log.Printf("[debug] end EvaluateReliabilities output worker: MergeInRange err: %v", err)
+					return
+				}
+			}
+		}
+	}()
+
 	for _, alert := range alerts {
 		if !o.matchAlert(alert) {
 			continue
 		}
-		tmp, err := alert.EvaluateReliabilities(timeFrame, o.cfg.TryReassessment)
-		if err != nil {
-			return nil, err
-		}
-		reliabilities, err = reliabilities.MergeInRange(tmp, startAt, endAt)
-		if err != nil {
-			return nil, err
-		}
+		inputQueue <- alert
 	}
+	close(inputQueue)
+
+	// wait input wokers done
+	if err := eg.Wait(); err != nil {
+		// send quit to output worker and wait output woker done.
+		close(quit)
+		wg.Wait()
+		return nil, err
+	}
+
+	// Evaluation of all alerts was completed. Close queue of ouptut and wait for merge process.
+	close(outputQueue)
+	wg.Wait()
 	return reliabilities, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mashiike/shimesaba/internal/timeutils"
 )
 
-//Config for App
+// Config for App
 type Config struct {
 	RequiredVersion string `yaml:"required_version" json:"required_version"`
 
@@ -360,8 +360,7 @@ func coalesceString(strs ...string) string {
 func coalesce[T any](elements ...*T) *T {
 	for _, element := range elements {
 		if element != nil {
-			var ret T
-			ret = *element
+			ret := *element
 			return &ret
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/shogo82148/go-retry v1.1.1
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.23.7
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/mackerel.go
+++ b/mackerel.go
@@ -59,10 +59,6 @@ func (repo *Repository) GetOrgName(ctx context.Context) (string, error) {
 	return org.Name, nil
 }
 
-const (
-	fetchMetricMetricmit = 6 * time.Hour
-)
-
 // SaveReports posts Reports to Mackerel
 func (repo *Repository) SaveReports(ctx context.Context, reports []*Report) error {
 	services := make(map[string][]*mackerel.MetricValue)


### PR DESCRIPTION
In the case of monitoring host and service metrics, there is the ability to retrieve the actual metrics and attempt to re-evaluate them.
When this feature is enabled, one evaluation is slower than the other.
Since a large number of alerts slows down the overall execution time, we decided to parallelize the evaluation of alerts.