### PR TITLE
if check monitor alerts, no GetMonitor API Call.

### DIFF
--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -63,3 +63,46 @@ func TestRepositoryFetchVirtualAlerts(t *testing.T) {
 		})
 	}
 }
+
+func TestRepositoryFetchAlerts(t *testing.T) {
+	client := newMockMackerelClient(t)
+	repo := shimesaba.NewRepository(client)
+
+	cases := []struct {
+		name     string
+		startAt  time.Time
+		endAt    time.Time
+		expected shimesaba.Alerts
+	}{
+		{
+			name:    "Alerts service",
+			startAt: time.Date(2021, 10, 1, 0, 5, 0, 0, time.UTC),
+			endAt:   time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC),
+			expected: shimesaba.Alerts{
+				{
+					OpenedAt: time.Date(2021, 10, 1, 0, 10, 0, 0, time.UTC),
+					Monitor:  shimesaba.NewMonitor("dummyMonitorID", "Dummy Service Metric Monitor", "service"),
+					ClosedAt: ptrTime(time.Date(2021, 10, 1, 0, 15, 0, 0, time.UTC)),
+				},
+			},
+		},
+		{
+			name:     "No alerts",
+			startAt:  time.Date(2022, 10, 1, 0, 5, 0, 0, time.UTC),
+			endAt:    time.Date(2022, 10, 1, 0, 15, 0, 0, time.UTC),
+			expected: shimesaba.Alerts{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			alerts, err := repo.FetchAlerts(context.Background(), c.startAt, c.endAt)
+			require.NoError(t, err)
+			for _, a := range alerts {
+				if a.Monitor != nil {
+					a.Monitor = a.Monitor.WithEvaluator(nil)
+				}
+			}
+			require.EqualValues(t, c.expected, alerts)
+		})
+	}
+}

--- a/mackerel_test.go
+++ b/mackerel_test.go
@@ -92,6 +92,18 @@ func TestRepositoryFetchAlerts(t *testing.T) {
 			endAt:    time.Date(2022, 10, 1, 0, 15, 0, 0, time.UTC),
 			expected: shimesaba.Alerts{},
 		},
+		{
+			name:    "check monitor",
+			startAt: time.Date(2021, 10, 1, 0, 17, 0, 0, time.UTC),
+			endAt:   time.Date(2021, 10, 1, 0, 18, 0, 0, time.UTC),
+			expected: shimesaba.Alerts{
+				{
+					OpenedAt: time.Date(2021, 10, 1, 0, 17, 0, 0, time.UTC),
+					Monitor:  shimesaba.NewMonitor("dummyCheckMonitorID", "check monitor dummyCheckMonitorID", "check"),
+					ClosedAt: nil,
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,7 @@
 package shimesaba_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -61,6 +62,14 @@ func (m *mockMackerelClient) FindWithClosedAlerts() (*mackerel.AlertsResp, error
 				Value:     0.01,
 				Type:      "service",
 			},
+			{
+				ID:        "dummyID20211001-00200",
+				Status:    "WARNING",
+				MonitorID: "dummyCheckMonitorID",
+				OpenedAt:  time.Date(2021, 10, 1, 0, 17, 0, 0, time.UTC).Unix(),
+				Value:     0.01,
+				Type:      "check",
+			},
 		},
 		NextID: "dummyNextID",
 	}, nil
@@ -85,12 +94,22 @@ func (m *mockMackerelClient) FindWithClosedAlertsByNextID(nextID string) (*macke
 }
 
 func (m *mockMackerelClient) GetMonitor(monitorID string) (mackerel.Monitor, error) {
-	require.Equal(m.t, "dummyMonitorID", monitorID)
-	return &mackerel.MonitorServiceMetric{
-		ID:   monitorID,
-		Name: "Dummy Service Metric Monitor",
-		Type: "service",
-	}, nil
+	switch monitorID {
+	case "dummyMonitorID":
+		return &mackerel.MonitorServiceMetric{
+			ID:   monitorID,
+			Name: "Dummy Service Metric Monitor",
+			Type: "service",
+		}, nil
+	case "dummyCheckMonitorID":
+		return nil, &mackerel.APIError{
+			StatusCode: 400,
+			Message:    "Cannot get a check monitor",
+		}
+	default:
+		require.Equal(m.t, "dummyMonitorID", monitorID)
+		return nil, errors.New("unexpected monitorID")
+	}
 }
 
 var graphAnnotations = []mackerel.GraphAnnotation{


### PR DESCRIPTION
Fix #122 

```go 
package main

import (
	"errors"
	"log"
	"os"

	"github.com/mackerelio/mackerel-client-go"
)

func main() {

	client := mackerel.NewClient(os.Getenv("MACKEREL_APIKEY"))
	monitor, err := client.GetMonitor("<check monitor id>") 

	if err != nil {
		var apiError *mackerel.APIError
		if errors.As(err, &apiError) {
			log.Fatalf("API error: %#v", apiError)
		}
		log.Fatal(err)
	}
	log.Printf("monitor: %v", monitor)
}
```

```bash
$ 2024/02/02 13:21:29 API error: &mackerel.APIError{StatusCode:400, Message:"Cannot get a check monitor"}
```

GetMonitor API Cannot get a check monitor. if alerts is check monitor, create dummy monitor object

I didn't know how to get the name of the check monitor from the API, so I can't get the SLO by the check monitor name, but I was able to avoid the error, so I'll go with this for now.

