### PR TITLE
 Ignore if it is an unknown monitor type error.

### DIFF
--- a/config.go
+++ b/config.go
@@ -250,6 +250,9 @@ func (c *AlertBasedSLIConfig) Restrict() error {
 	if c.MonitorNameSuffix != "" {
 		return nil
 	}
+	if c.MonitorType != "" {
+		return nil
+	}
 
 	return errors.New("either monitor_id, monitor_name, monitor_name_prefix, monitor_name_suffix or monitor_type is required")
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/handlename/ssmwrap v1.2.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kayac/go-config v0.7.0
-	github.com/mackerelio/mackerel-client-go v0.26.0
+	github.com/mackerelio/mackerel-client-go v0.30.0
 	github.com/shogo82148/go-retry v1.1.1
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli/v2 v2.25.7

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/kayac/go-config v0.7.0/go.mod h1:Nfkw4LZOh/7HGepftBvD2lKEpPyl1Vp89yA7
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/mackerelio/mackerel-client-go v0.26.0 h1:72hj2zw/rqTUNMNokenRxs6KfJ1aVxRHpZT8X4eOUuA=
 github.com/mackerelio/mackerel-client-go v0.26.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
+github.com/mackerelio/mackerel-client-go v0.30.0 h1:JCusfP7JfRT0fY136xBbaKHHh8X2/CQBO7TG8JNVC2Y=
+github.com/mackerelio/mackerel-client-go v0.30.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/mackerel.go
+++ b/mackerel.go
@@ -26,7 +26,7 @@ type MackerelClient interface {
 	GetMonitor(monitorID string) (mackerel.Monitor, error)
 	FindMonitors() ([]mackerel.Monitor, error)
 
-	FindGraphAnnotations(service string, from int64, to int64) ([]mackerel.GraphAnnotation, error)
+	FindGraphAnnotations(service string, from int64, to int64) ([]*mackerel.GraphAnnotation, error)
 }
 
 // Repository handles reading and writing data

--- a/mackerel.go
+++ b/mackerel.go
@@ -260,7 +260,12 @@ func (repo *Repository) convertAlerts(resp *mackerel.AlertsResp) ([]*Alert, erro
 			var err error
 			monitor, err = repo.getMonitor(alert.MonitorID, alert.Type)
 			if err != nil {
-				return nil, fmt.Errorf("get monitor for alert `%s`: %w", alert.ID, err)
+				if strings.Contains(err.Error(), "unknown monitor type:") {
+					log.Printf("[warn] alert[%s].MonitorID=%s, unknown monitor type: %s", alert.ID, alert.MonitorID, alert.Type)
+					monitor = NewMonitor(alert.MonitorID, alert.MonitorID, alert.Type)
+				} else {
+					return nil, fmt.Errorf("get monitor for alert `%s`: %w", alert.ID, err)
+				}
 			}
 		}
 		a := NewAlert(

--- a/mock_test.go
+++ b/mock_test.go
@@ -112,7 +112,7 @@ func (m *mockMackerelClient) GetMonitor(monitorID string) (mackerel.Monitor, err
 	}
 }
 
-var graphAnnotations = []mackerel.GraphAnnotation{
+var graphAnnotations = []*mackerel.GraphAnnotation{
 	{
 		ID:          "xxxxxxxxxxx",
 		Title:       "hogehogehoge",
@@ -136,7 +136,7 @@ var graphAnnotations = []mackerel.GraphAnnotation{
 	},
 }
 
-func (m *mockMackerelClient) FindGraphAnnotations(service string, from int64, to int64) ([]mackerel.GraphAnnotation, error) {
+func (m *mockMackerelClient) FindGraphAnnotations(service string, from int64, to int64) ([]*mackerel.GraphAnnotation, error) {
 	require.Equal(m.t, "shimesaba", service)
 
 	return graphAnnotations, nil


### PR DESCRIPTION
for https://github.com/mashiike/shimesaba/issues/136

New monitor types added in beta.

However, because the go SDK is not yet compatible, an error like the issue above will occur.

This PR is a temporary measure, so that if the error contains the characters `unknown monitor type:`, the unknown monitor will be temporarily filled in and returned.

This should prevent Shimesaba as a whole from failing.